### PR TITLE
Fix error propagation

### DIFF
--- a/src/matter/ControllerNode.ts
+++ b/src/matter/ControllerNode.ts
@@ -37,7 +37,8 @@ export interface ControllerCreateOptions {
 
 interface AddDeviceResult {
     result: boolean;
-    error?: Error;
+    /** The error message */
+    error?: string;
     nodeId?: string;
 }
 
@@ -625,7 +626,7 @@ class Controller implements GeneralNode {
         device: CommissionableDevice,
     ): Promise<AddDeviceResult> {
         if (!this.#commissioningController) {
-            return { error: new Error('Controller is not activated.'), result: false };
+            return { error: 'Controller is not activated.', result: false };
         }
         const commissioningOptions: CommissioningOptions = {
             regulatoryLocation: GeneralCommissioning.RegulatoryLocationType.IndoorOutdoor,
@@ -710,7 +711,7 @@ class Controller implements GeneralNode {
         if (!this.#commissioningController) {
             return {
                 result: false,
-                error: new Error(`Can not register NodeId "${nodeId}" because controller not initialized.`),
+                error: `Can not register NodeId "${nodeId}" because controller not initialized.`,
             };
         }
 

--- a/src/matter/ControllerNode.ts
+++ b/src/matter/ControllerNode.ts
@@ -701,9 +701,9 @@ class Controller implements GeneralNode {
             await this.registerCommissionedNode(nodeId);
 
             return { result: true, nodeId: nodeId.toString() };
-        } catch (error) {
-            this.#adapter.log.info(`Commissioning failed: ${error.stack}`);
-            return { error, result: false };
+        } catch (e) {
+            this.#adapter.log.info(`Commissioning failed: ${e.stack}`);
+            return { error: e.message, result: false };
         }
     }
 


### PR DESCRIPTION
on sendTos of course javascript instances of e.g. Error are getting reduced to ``{}``