### PR TITLE
Allow ProductID+Passcode discovery

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,9 +12,9 @@
         "@iobroker/adapter-core": "^3.1.6",
         "@iobroker/dm-utils": "^0.3.1",
         "@iobroker/type-detector": "^4.0.1",
-        "@project-chip/matter-node.js": "0.10.0-alpha.0-20240817-923902e8",
-        "@project-chip/matter.js": "0.10.0-alpha.0-20240817-923902e8",
-        "axios": "^1.7.2",
+        "@project-chip/matter-node.js": "0.10.3",
+        "@project-chip/matter.js": "0.10.3",
+        "axios": "^1.7.7",
         "jsonwebtoken": "^9.0.2"
       },
       "devDependencies": {
@@ -22,10 +22,10 @@
         "@alcalzone/release-script-plugin-iobroker": "^3.7.2",
         "@alcalzone/release-script-plugin-license": "^3.7.0",
         "@iobroker/dev-server": "^0.7.3",
-        "@iobroker/legacy-testing": "^1.0.12",
-        "@iobroker/types": "^6.0.9",
+        "@iobroker/legacy-testing": "^1.0.13",
+        "@iobroker/types": "^6.0.11",
         "@types/jsonwebtoken": "^9.0.6",
-        "@types/node": "^22.3.0",
+        "@types/node": "^22.5.5",
         "@typescript-eslint/eslint-plugin": "^7.18.0",
         "chai": "^4.5.0",
         "colorette": "^2.0.20",
@@ -49,7 +49,7 @@
         "node": ">=16"
       },
       "optionalDependencies": {
-        "@project-chip/matter-node-ble.js": "0.10.0-alpha.0-20240817-923902e8"
+        "@project-chip/matter-node-ble.js": "0.10.3"
       }
     },
     "node_modules/@alcalzone/pak": {
@@ -549,13 +549,14 @@
       }
     },
     "node_modules/@iobroker/legacy-testing": {
-      "version": "1.0.12",
-      "resolved": "https://registry.npmjs.org/@iobroker/legacy-testing/-/legacy-testing-1.0.12.tgz",
-      "integrity": "sha512-2kO9SgAuOp8njtJPXyEnCvbmEKxGeQSEP3YjZawHYno3jF9XK/h/fOaASp9xWkQ5C18b6nV7JA4PFrByTJG8RA==",
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/@iobroker/legacy-testing/-/legacy-testing-1.0.13.tgz",
+      "integrity": "sha512-1ksISxpGyG8lKRRx6poe17otu0Ql5YculMNYXaE4mM4cF53eKv8y9JktDN2GIQan5+ieF/cREvwgQApOLWBUGw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "chai": "^4.4.1",
-        "mocha": "^10.4.0"
+        "chai": "^4.5.0",
+        "mocha": "^10.7.3"
       }
     },
     "node_modules/@iobroker/testing": {
@@ -580,9 +581,10 @@
       "integrity": "sha512-fXB93xg6CkFWO1fft1/ATwBsz5bitLGl1dKadpDYEh8ClKzO07BUTQabWpLGQu+oPIsFP/5qTKSBmUXMn2JIlA=="
     },
     "node_modules/@iobroker/types": {
-      "version": "6.0.9",
-      "resolved": "https://registry.npmjs.org/@iobroker/types/-/types-6.0.9.tgz",
-      "integrity": "sha512-8+u5c/cawj5cmnQaW95TJv1vBMs68GaepPko7urvylGfixPE/vJ0nwNq392v67B52PwHPi41kctmR9gNt9M+tw==",
+      "version": "6.0.11",
+      "resolved": "https://registry.npmjs.org/@iobroker/types/-/types-6.0.11.tgz",
+      "integrity": "sha512-RNDURjtL5Cm9wt6ocCqdRi86Qx1350zBIvvrJ9+Fjgasoi6cWCdoOghkwEeb95TH2j//q/uLqWwL8SZ0vxx6Kw==",
+      "license": "MIT",
       "engines": {
         "node": ">=12.0.0"
       }
@@ -684,22 +686,27 @@
       }
     },
     "node_modules/@noble/curves": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.5.0.tgz",
-      "integrity": "sha512-J5EKamIHnKPyClwVrzmaf5wSdQXgdHcPZIZLu3bwnbeCx8/7NPK5q2ZBWF+5FvYGByjiQQsJYX6jfgB2wDPn3A==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.6.0.tgz",
+      "integrity": "sha512-TlaHRXDehJuRNR9TfZDNQ45mMEd5dwUwmicsafcIX4SsNiqnCHKjE/1alYPd/lDRVhxdhUAlv8uEhMCI5zjIJQ==",
+      "license": "MIT",
       "dependencies": {
-        "@noble/hashes": "1.4.0"
+        "@noble/hashes": "1.5.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@noble/hashes": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.4.0.tgz",
-      "integrity": "sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.5.0.tgz",
+      "integrity": "sha512-1j6kQFb7QRru7eKN3ZDvRcP13rugwdxZqCjbiAVZfIJwgj2A65UmT4TgARXGlXgnRkORLTDTrO19ZErt7+QXgA==",
+      "license": "MIT",
       "engines": {
-        "node": ">= 16"
+        "node": "^14.21.3 || >=16"
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
@@ -849,12 +856,13 @@
       }
     },
     "node_modules/@project-chip/matter-node-ble.js": {
-      "version": "0.10.0-alpha.0-20240817-923902e8",
-      "resolved": "https://registry.npmjs.org/@project-chip/matter-node-ble.js/-/matter-node-ble.js-0.10.0-alpha.0-20240817-923902e8.tgz",
-      "integrity": "sha512-RC98BU65DiSl3j/BeJIwWhFUpGTjwo75d6QINqkUiU7+psZF2yDL9cMg9nVHpj4RLPxrjmgaTKMLo6R0Wjil7A==",
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@project-chip/matter-node-ble.js/-/matter-node-ble.js-0.10.3.tgz",
+      "integrity": "sha512-a4YEbd/GhCuqfOnKroc1imhOOQVP/9WNcRHw921H07uakG8r+Cl23r/rO+CNLJg+VQGH4gTmPWDix/pbDivqzw==",
+      "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
-        "@project-chip/matter.js": "0.10.0-alpha.0-20240817-923902e8"
+        "@project-chip/matter.js": "0.10.3"
       },
       "engines": {
         "node": ">=18.0.0"
@@ -865,11 +873,12 @@
       }
     },
     "node_modules/@project-chip/matter-node.js": {
-      "version": "0.10.0-alpha.0-20240817-923902e8",
-      "resolved": "https://registry.npmjs.org/@project-chip/matter-node.js/-/matter-node.js-0.10.0-alpha.0-20240817-923902e8.tgz",
-      "integrity": "sha512-LJ4fGxzKdZnsjD6nQDK+Q9+qzPP127ISzVnDmAI+se7XfHxpJgcj1Y4KFdKZ7yisjEIBE4aJmo3x/uiM5iQCXw==",
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@project-chip/matter-node.js/-/matter-node.js-0.10.3.tgz",
+      "integrity": "sha512-XYIGRYWk7YsjR/M6t6RWQxUr5EIXUqblAna5s3d/AAUpPgdGh3KYZblUex0mdtuIfcozn8Lcov/M44JgfgkMGw==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@project-chip/matter.js": "0.10.0-alpha.0-20240817-923902e8",
+        "@project-chip/matter.js": "0.10.3",
         "node-localstorage": "^3.0.5"
       },
       "engines": {
@@ -877,9 +886,10 @@
       }
     },
     "node_modules/@project-chip/matter.js": {
-      "version": "0.10.0-alpha.0-20240817-923902e8",
-      "resolved": "https://registry.npmjs.org/@project-chip/matter.js/-/matter.js-0.10.0-alpha.0-20240817-923902e8.tgz",
-      "integrity": "sha512-2Iba4W+GjxLDslAKRFUv/ZvJnBZIFEhKszNlfVj2DV1RUGzhvUKulmOg72Kcw0XUL2v0KdNi+zfKBitQd6H0lQ==",
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@project-chip/matter.js/-/matter.js-0.10.3.tgz",
+      "integrity": "sha512-4GtBCN4ZHbmzn67oBDnZBxPhemOsWoErp9ZWRKEJNBEIYPMvyG6N01zNO+NU2IdUmMDOj6SWbIfTJUQ/M1Cy3Q==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@noble/curves": "^1.5.0"
       }
@@ -1339,12 +1349,13 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "22.3.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.3.0.tgz",
-      "integrity": "sha512-nrWpWVaDZuaVc5X84xJ0vNrLvomM205oQyLsRt7OHNZbSHslcWsvgFR7O7hire2ZonjLrWBbedmotmIlJDVd6g==",
+      "version": "22.5.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.5.5.tgz",
+      "integrity": "sha512-Xjs4y5UPO/CLdzpgR6GirZJx36yScjh73+2NlLlkFRSoQN8B0DpfXPdZGnvVmLRLOsqDpOfTNv7D9trgGhmOIA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.18.2"
+        "undici-types": "~6.19.2"
       }
     },
     "node_modules/@types/yauzl": {
@@ -2481,9 +2492,10 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.2.tgz",
-      "integrity": "sha512-2A8QhOMrbomlDuiLeK9XibIBzuHeRcqqNOHp0Cyp5EoJ1IFDh+XZH3A6BkXtv0K4gFGCI0Y4BM7B1wOEi0Rmgw==",
+      "version": "1.7.7",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.7.tgz",
+      "integrity": "sha512-S4kL7XrjgBmvdGut0sN3yJxqYzrDOnivkBiN0OFs6hLiUam3UPvswUo0kqGyhqUZGEOytHyumEdXsAkgCOUf3Q==",
+      "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",
@@ -9864,10 +9876,11 @@
       }
     },
     "node_modules/mocha": {
-      "version": "10.7.0",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-10.7.0.tgz",
-      "integrity": "sha512-v8/rBWr2VO5YkspYINnvu81inSz2y3ODJrhO175/Exzor1RcEZZkizgE2A+w/CAXXoESS8Kys5E62dOHGHzULA==",
+      "version": "10.7.3",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-10.7.3.tgz",
+      "integrity": "sha512-uQWxAu44wwiACGqjbPYmjo7Lg8sFrS3dQe7PP2FQI+woptP4vZXSMcfMyFL/e1yFEeEpV4RtyTpZROOKmxis+A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ansi-colors": "^4.1.3",
         "browser-stdout": "^1.3.1",
@@ -13888,10 +13901,11 @@
       "dev": true
     },
     "node_modules/undici-types": {
-      "version": "6.18.2",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.18.2.tgz",
-      "integrity": "sha512-5ruQbENj95yDYJNS3TvcaxPMshV7aizdv/hWYjGIKoANWKjhWNBsr2YEuYZKodQulB1b8l7ILOuDQep3afowQQ==",
-      "dev": true
+      "version": "6.19.8",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
+      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/union-value": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -19,15 +19,15 @@
     "url": "https://github.com/ioBroker/ioBroker.matter"
   },
   "optionalDependencies": {
-    "@project-chip/matter-node-ble.js": "0.10.0-alpha.0-20240817-923902e8"
+    "@project-chip/matter-node-ble.js": "0.10.3"
   },
   "dependencies": {
     "@iobroker/adapter-core": "^3.1.6",
     "@iobroker/dm-utils": "^0.3.1",
     "@iobroker/type-detector": "^4.0.1",
-    "@project-chip/matter-node.js": "0.10.0-alpha.0-20240817-923902e8",
-    "@project-chip/matter.js": "0.10.0-alpha.0-20240817-923902e8",
-    "axios": "^1.7.2",
+    "@project-chip/matter-node.js": "0.10.3",
+    "@project-chip/matter.js": "0.10.3",
+    "axios": "^1.7.7",
     "jsonwebtoken": "^9.0.2"
   },
   "devDependencies": {
@@ -35,10 +35,10 @@
     "@alcalzone/release-script-plugin-iobroker": "^3.7.2",
     "@alcalzone/release-script-plugin-license": "^3.7.0",
     "@iobroker/dev-server": "^0.7.3",
-    "@iobroker/legacy-testing": "^1.0.12",
-    "@iobroker/types": "^6.0.9",
+    "@iobroker/legacy-testing": "^1.0.13",
+    "@iobroker/types": "^6.0.11",
     "@types/jsonwebtoken": "^9.0.6",
-    "@types/node": "^22.3.0",
+    "@types/node": "^22.5.5",
     "@typescript-eslint/eslint-plugin": "^7.18.0",
     "chai": "^4.5.0",
     "colorette": "^2.0.20",

--- a/src/matter/ControllerNode.ts
+++ b/src/matter/ControllerNode.ts
@@ -45,7 +45,7 @@ interface AddDeviceResult {
 type EndUserCommissioningOptions = (
     | { qrCode: string }
     | { manualCode: string }
-    | { passCode: number; vendorId: number; productId: number; ip: string; port: number }
+    | { passcode: number; vendorId: number; productId: number; ip: string; port: number }
 ) & { device: CommissionableDevice };
 
 // const IGNORE_CLUSTERS: ClusterId[] = [
@@ -668,7 +668,7 @@ class Controller implements GeneralNode {
             shortDiscriminator = undefined;
             passcode = pairingCodeCodec[0].passcode;
         } else if ('passcode' in data) {
-            passcode = data.passCode;
+            passcode = data.passcode;
             // TODO also use vendor Id once matter.js can discover for both together
             // TODO also try ip/port once matter.js can use this without a full discoverableDevice
             //vendorId = data.vendorId;

--- a/src/matter/ControllerNode.ts
+++ b/src/matter/ControllerNode.ts
@@ -42,11 +42,11 @@ interface AddDeviceResult {
     nodeId?: string;
 }
 
-interface EndUserCommissioningOptions {
-    qrCode?: string;
-    manualCode?: string;
-    device: CommissionableDevice;
-}
+type EndUserCommissioningOptions = (
+    | { qrCode: string }
+    | { manualCode: string }
+    | { passCode: number; vendorId: number; productId: number; ip: string; port: string }
+) & { device: CommissionableDevice };
 
 // const IGNORE_CLUSTERS: ClusterId[] = [
 //     ClusterId(0x0004), // Groups
@@ -156,7 +156,7 @@ class Controller implements GeneralNode {
                 case 'controllerCommissionDevice':
                     // Commission a new device with Commissioning payloads like a QR Code or pairing code
                     const options = message as EndUserCommissioningOptions;
-                    return await this.commissionDevice(options.qrCode, options.manualCode, options.device);
+                    return await this.commissionDevice(options);
                 case 'controllerDeviceQrCode':
                     // Opens a new commissioning window for a paired node and returns the QRCode and pairing code for display
                     return { result: await this.showNewCommissioningCode(message.nodeId) };
@@ -620,11 +620,7 @@ class Controller implements GeneralNode {
         // nothing to do
     }
 
-    async commissionDevice(
-        qrCode: string | undefined,
-        manualCode: string | undefined,
-        device: CommissionableDevice,
-    ): Promise<AddDeviceResult> {
+    async commissionDevice(data: EndUserCommissioningOptions): Promise<AddDeviceResult> {
         if (!this.#commissioningController) {
             return { error: 'Controller is not activated.', result: false };
         }
@@ -655,21 +651,30 @@ class Controller implements GeneralNode {
             }
         }
 
-        let passcode: number | undefined;
-        let shortDiscriminator: number | undefined;
-        let longDiscriminator: number | undefined;
-        if (manualCode) {
-            const pairingCodeCodec = ManualPairingCodeCodec.decode(manualCode);
+        let passcode: number | undefined = undefined;
+        let shortDiscriminator: number | undefined = undefined;
+        let longDiscriminator: number | undefined = undefined;
+        let productId: number | undefined = undefined;
+        //let vendorId: number | undefined = undefined;
+        if ('manualCode' in data) {
+            const pairingCodeCodec = ManualPairingCodeCodec.decode(data.manualCode);
             shortDiscriminator = pairingCodeCodec.shortDiscriminator;
             longDiscriminator = undefined;
             passcode = pairingCodeCodec.passcode;
-        } else if (qrCode) {
-            const pairingCodeCodec = QrPairingCodeCodec.decode(qrCode);
+        } else if ('qrCode' in data) {
+            const pairingCodeCodec = QrPairingCodeCodec.decode(data.qrCode);
             // TODO handle the case where multiple devices are included
             longDiscriminator = pairingCodeCodec[0].discriminator;
             shortDiscriminator = undefined;
             passcode = pairingCodeCodec[0].passcode;
+        } else if ('passcode' in data) {
+            passcode = data.passCode;
+            // TODO also use vendor Id once matter.js can discover for both together
+            // TODO also try ip/port once matter.js can use this without a full discoverableDevice
+            //vendorId = data.vendorId;
+            productId = data.productId;
         }
+        const { device } = data;
         if (device) {
             longDiscriminator = undefined;
             shortDiscriminator = undefined;
@@ -691,7 +696,9 @@ class Controller implements GeneralNode {
                             ? { longDiscriminator }
                             : shortDiscriminator !== undefined
                               ? { shortDiscriminator }
-                              : undefined,
+                              : productId !== undefined
+                                ? { productId }
+                                : undefined,
                 },
                 passcode,
             };

--- a/src/matter/ControllerNode.ts
+++ b/src/matter/ControllerNode.ts
@@ -45,7 +45,7 @@ interface AddDeviceResult {
 type EndUserCommissioningOptions = (
     | { qrCode: string }
     | { manualCode: string }
-    | { passCode: number; vendorId: number; productId: number; ip: string; port: string }
+    | { passCode: number; vendorId: number; productId: number; ip: string; port: number }
 ) & { device: CommissionableDevice };
 
 // const IGNORE_CLUSTERS: ClusterId[] = [


### PR DESCRIPTION
This PR adds the option to also discover by prodictid/vendorid needed for Google. because matter.js currently do not allow to discover for product AND vendor id only the product id is used for now. also IP/Port is ignored. 

matter.js task: https://github.com/orgs/project-chip/projects/11/views/1?pane=issue&itemId=79842108