### PR TITLE
[OFFICIAL RELEASE] 0.2.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,8 +218,7 @@ TBD
 -->
 
 ## Changelog
-
-### __WORK IN PROGRESS__
+### 0.2.5 (2024-12-06)
 * (@Apollon77) Sets the "no-compose" flag correctly to normally use composed if needed and adds it to a missing dialog
 * (@Apollon77) Allows to use null values if needed
 * (@Apollon77) Fixes UNREACH handling for devices

--- a/io-package.json
+++ b/io-package.json
@@ -1,8 +1,21 @@
 {
   "common": {
     "name": "matter",
-    "version": "0.2.4",
+    "version": "0.2.5",
     "news": {
+      "0.2.5": {
+        "en": "Sets the \"no-compose\" flag correctly to normally use composed if needed and adds it to a missing dialog\nAllows to use null values if needed\nFixes UNREACH handling for devices\nFixes object change handling for controller\nAllow Bridges to expose its name as a device name\nAllows to rename controller nodes and devices",
+        "de": "Setzt das \"no-compose\"-Flag richtig ein, um normalerweise komponiert zu verwenden und fügt es zu einem fehlenden Dialog hinzu\nErlaubt, bei Bedarf Nullwerte zu verwenden\nBehebt UNREACH-Handling für Geräte\nFixes Objektänderungshandling für Controller\nErlaubt Bridges, seinen Namen als Gerätenamen zu entlarven\nErmöglicht die Umbenennung von Controller-Knoten und -Geräten",
+        "ru": "Установить флаг «без композиций» правильно, чтобы обычно использовать его, если это необходимо, и добавить его в недостающий диалог\nПозволяет использовать нулевые значения в случае необходимости\nFixes UNREACH для устройств\nИсправление изменения объекта для контроллера\nПозволяет Bridges разоблачить свое имя как имя устройства\nПозволяет переименовать узлы и устройства контроллера",
+        "pt": "Define a bandeira \"não compor\" corretamente para usar normalmente composta se necessário e adiciona-a a uma caixa de diálogo ausente\nPermite usar valores nulos se necessário\nCorrige o manuseio UNREACH para dispositivos\nCorrige o manuseio de alterações de objetos para o controlador\nPermitir que Bridges exponha seu nome como um nome de dispositivo\nPermite renomear nós de controlador e dispositivos",
+        "nl": "Stelt de \"no-compose\"-vlag correct in om gecomposed te gebruiken indien nodig en voegt deze toe aan een ontbrekend dialoogvenster\nHiermee kunt u zo nodig nulwaarden gebruiken\nBevestigt UNREACH-afhandeling voor apparaten\nHerstelt object verandering behandeling voor controller\nBruggen toestaan om haar naam als apparaatnaam te ontmaskeren\nHiermee kunt u controllerknooppunten en -apparaten hernoemen",
+        "fr": "Définit le drapeau \"non-composant\" correctement pour utiliser normalement composé si nécessaire et l'ajoute à une boîte de dialogue manquante\nPermet d'utiliser des valeurs null si nécessaire\nCorrige la manipulation d'UNREACH pour les appareils\nCorrection de la manipulation du changement d'objet pour le contrôleur\nPermettre à Bridges d'exposer son nom comme un nom d'appareil\nPermet de renommer les nœuds et les périphériques du contrôleur",
+        "it": "Imposta la bandiera \"no-compose\" correttamente per utilizzare normalmente composta se necessario e aggiungerla a una finestra di dialogo mancante\nConsente di utilizzare valori null se necessario\nFissa la gestione UNREACH per dispositivi\nRisolve la gestione del cambiamento degli oggetti per il controller\nConsente a Bridges di esporre il suo nome come nome di un dispositivo\nConsente di rinominare nodi e dispositivi del controller",
+        "es": "Establece la bandera \"no-compos\" correctamente para usar normalmente compuesta si es necesario y la añade a un diálogo perdido\nPermite utilizar valores nulos si es necesario\nFija el manejo UNREACH para dispositivos\nArregla el manejo del cambio de objeto para el controlador\nPermitir a Bridges exponer su nombre como un nombre de dispositivo\nPermite renombrar nodos y dispositivos controlador",
+        "pl": "Ustawia flagę \"no- composite\" poprawnie, aby normalnie używać skomponowanego w razie potrzeby i dodaje ją do brakującego okna dialogowego\nPozwala na użycie wartości zerowych w razie potrzeby\nFixes UNREACH obsługi urządzeń\nUstawia obsługę zmiany obiektu dla kontrolera\nPozwól Mostkom na ujawnienie nazwy urządzenia\nUmożliwia zmianę nazwy węzłów i urządzeń sterownika",
+        "uk": "Встановіть прапорець \"no-compose\" правильно, щоб зазвичай використовувати, що складається, якщо потрібно і додає його до відсутній діалог\nДозволяє використовувати значення null, якщо потрібно\nВиправлення роботи UNREACH для пристроїв\nВиправлення управління змінами об'єкта для контролера\nДозволяє мостів, щоб виставити ім'я пристрою\nДозволяє перейменувати вузли контролера і пристрої",
+        "zh-cn": "设置“ 无编解” 旗帜, 以便在必要时正常使用编解, 并将其添加到缺少的对话框中\n需要时允许使用无效值\n修复设备的UNREACH处理\n修正控制器对象更改处理\n允许 Bridges 将其名称曝光为设备名称\n允许重命名控制器节点和设备"
+      },
       "0.2.4": {
         "en": "Shows a progress indicator when deleting controller nodes\nCuts names and labels to 32 or 64 characters as needed by Matter\nImproves error handling on devices and bridges\nClear storage when removing a bridged device\nProcesses changed objects with a 5s delay to prevent too many changes at once\nFixes version determination\nInitializes Device objects more lazily",
         "de": "Zeigt einen Fortschrittsindikator beim Löschen von Controller-Knoten\nSchneidet Namen und Labels auf 32 oder 64 Zeichen nach Bedarf von Matter\nVerbessert die Fehlerbehandlung auf Geräten und Brücken\nLöschen Sie die Speicherung beim Entfernen eines überbrückten Geräts\nProzesse veränderten Objekte mit einer Verzögerung von 5s, um zu viele Änderungen auf einmal zu verhindern\nBehebt die Versionsbestimmung\nInitialisiert Geräteobjekte mehr lazily",
@@ -69,19 +82,6 @@
         "zh-cn": "突破变化! 在安装此版本之前, 请取消所有设备的功能, 并重新安装适配器 。 之后给新设备配对.\n最终确定设备、桥梁和控制器的功能,第一套有11个设备类型\n升级到新的 Matter.js 版本和 API( 中断存储结构)\n将图形用户界面的构建进程移至 vite\n添加到 GUI 中组设备的可能性"
       },
       "0.1.13": {
-        "en": "Working on the controller",
-        "de": "Arbeiten am Controller",
-        "ru": "Работает на контроллере",
-        "pt": "Trabalhando no controlador",
-        "nl": "Werken aan de controller",
-        "fr": "Travailler sur le contrôleur",
-        "it": "Lavorare sul controller",
-        "es": "Trabajando en el controlador",
-        "pl": "Prace nad kontrolerem",
-        "uk": "Робота на контролері",
-        "zh-cn": "控制员的工作"
-      },
-      "0.1.11": {
         "en": "Working on the controller",
         "de": "Arbeiten am Controller",
         "ru": "Работает на контроллере",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "iobroker.matter",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "iobroker.matter",
-      "version": "0.2.4",
+      "version": "0.2.5",
       "license": "Apache-2.0",
       "dependencies": {
         "@iobroker/adapter-core": "^3.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "iobroker.matter",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "Controlling and simulation of matter devices",
   "author": {
     "name": "Denis Haev",

--- a/src-admin/package.json
+++ b/src-admin/package.json
@@ -1,6 +1,6 @@
 {
     "name": "iobroker.matter",
-    "version": "0.2.4",
+    "version": "0.2.5",
     "private": true,
     "optionalDependencies": {
         "@rollup/rollup-linux-x64-gnu": "*"


### PR DESCRIPTION
* (@Apollon77) Sets the "no-compose" flag correctly to normally use composed if needed and adds it to a missing dialog%0A* (@Apollon77) Allows to use null values if needed%0A* (@Apollon77) Fixes UNREACH handling for devices%0A* (@Apollon77) Fixes object change handling for controller%0A* (@Apollon77) Allow Bridges to expose its name as a device name%0A* (@Apollon77) Allows to rename controller nodes and devices