### PR TITLE
Update181224

### DIFF
--- a/.github/workflows/test-and-release.yml
+++ b/.github/workflows/test-and-release.yml
@@ -93,6 +93,8 @@ jobs:
                   UPDATE_LABELS: 'automated pr 🔧'
                   MERGE_METHOD: 'squash'
                   MERGE_COMMIT_MESSAGE: 'pull-request-title-and-description'
+                  MERGE_RETRIES: "50"
+                  MERGE_RETRY_SLEEP: "30000"
 
             - name: Checkout repository
               if: steps.automerge.outputs.mergeResult == 'merged'
@@ -167,6 +169,6 @@ jobs:
                   export SENTRY_URL=https://sentry.iobroker.net
                   export SENTRY_ORG=iobroker
                   export SENTRY_PROJECT=iobroker-matter
-                  export SENTRY_VERSION=iobroker.matter@${{ env.VERSION }}
+                  export SENTRY_VERSION=iobroker.matter@${{ steps.version.outputs.result }}
                   sentry-cli releases new $SENTRY_VERSION
                   sentry-cli releases finalize $SENTRY_VERSION

--- a/README.md
+++ b/README.md
@@ -220,6 +220,18 @@ TBD
 -->
 
 ## Changelog
+
+### __WORK IN PROGRESS__
+* (@Apollon77) When Get and set states are separated then also update set state with new values
+* (@Apollon77) Node details dialog in controller now exposes some more Battery information
+* (@Apollon77) Also exposes the battery states when features are set wrong on the device
+* (@Apollon77) Fixes LightSensor state mapping
+* (@Apollon77) Prevents errors when only some energy states exist
+* (@Apollon77) Uses the IP provided by Android when commissioning devices if possible
+* (@Apollon77) Restructure discovery to run in background and not block the UI
+* (@Apollon77) Exposes States for Enums for Matter nodes
+* (@Apollon77) Prevent storage to delete wrong data when a node gets removed
+
 ### 0.2.8 (2024-12-17)
 * (@bluefox) Fixes progress dialog for DM - used when deleting a node
 * (@bluefox) Synchronizes the "do not ask again on delete" time with admin and set to 5 minutes

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,9 +13,9 @@
         "@iobroker/dm-utils": "^0.6.11",
         "@iobroker/i18n": "^0.3.1",
         "@iobroker/type-detector": "^4.1.1",
-        "@matter/main": "0.11.9",
-        "@matter/nodejs": "0.11.9",
-        "@project-chip/matter.js": "0.11.9",
+        "@matter/main": "0.12.0-alpha.0-20241218-de74d9dc7",
+        "@matter/nodejs": "0.12.0-alpha.0-20241218-de74d9dc7",
+        "@project-chip/matter.js": "0.12.0-alpha.0-20241218-de74d9dc7",
         "axios": "^1.7.9",
         "jsonwebtoken": "^9.0.2"
       },
@@ -40,7 +40,7 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@matter/nodejs-ble": "0.11.9"
+        "@matter/nodejs-ble": "0.12.0-alpha.0-20241218-de74d9dc7"
       }
     },
     "node_modules/@alcalzone/pak": {
@@ -1001,64 +1001,64 @@
       }
     },
     "node_modules/@matter/general": {
-      "version": "0.11.9",
-      "resolved": "https://registry.npmjs.org/@matter/general/-/general-0.11.9.tgz",
-      "integrity": "sha512-7TsG7/2xQMDq/qaHcx52H0KxQajV19CrhUGbf7NlxIzTYeUFBdr6ddxELuUVfGLIKS8NNwL8bs43kgOBV7VUsA==",
+      "version": "0.12.0-alpha.0-20241218-de74d9dc7",
+      "resolved": "https://registry.npmjs.org/@matter/general/-/general-0.12.0-alpha.0-20241218-de74d9dc7.tgz",
+      "integrity": "sha512-c/mfpDJ21lIqpw0ezdqtuWBoiy/OEylYi0PiuieXbo8n+1PfYDXT8pap2v7FObLPL/2suZCnbvCkHosJQsSRqA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@noble/curves": "^1.7.0"
       }
     },
     "node_modules/@matter/main": {
-      "version": "0.11.9",
-      "resolved": "https://registry.npmjs.org/@matter/main/-/main-0.11.9.tgz",
-      "integrity": "sha512-CrGsvUq/aI4h2TsbupkUJGWnN92YfLIj++8eKXbF3X9PZqVLun6e5HAxUdgIJ33jdPFpSLXeCObuPhLCmxliLQ==",
+      "version": "0.12.0-alpha.0-20241218-de74d9dc7",
+      "resolved": "https://registry.npmjs.org/@matter/main/-/main-0.12.0-alpha.0-20241218-de74d9dc7.tgz",
+      "integrity": "sha512-2qVF4BDrOL90yX+uFsnqnYQnVzOn8xzwSkvmzNl23xeJsx7TfvoMDguosVEhh+aB1nqTpFw6x5q8Sn5Kw7232w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@matter/general": "0.11.9",
-        "@matter/model": "0.11.9",
-        "@matter/node": "0.11.9",
-        "@matter/protocol": "0.11.9",
-        "@matter/types": "0.11.9",
+        "@matter/general": "0.12.0-alpha.0-20241218-de74d9dc7",
+        "@matter/model": "0.12.0-alpha.0-20241218-de74d9dc7",
+        "@matter/node": "0.12.0-alpha.0-20241218-de74d9dc7",
+        "@matter/protocol": "0.12.0-alpha.0-20241218-de74d9dc7",
+        "@matter/types": "0.12.0-alpha.0-20241218-de74d9dc7",
         "@noble/curves": "^1.7.0"
       },
       "optionalDependencies": {
-        "@matter/nodejs": "0.11.9"
+        "@matter/nodejs": "0.12.0-alpha.0-20241218-de74d9dc7"
       }
     },
     "node_modules/@matter/model": {
-      "version": "0.11.9",
-      "resolved": "https://registry.npmjs.org/@matter/model/-/model-0.11.9.tgz",
-      "integrity": "sha512-WU/SkLjeAScBiVwmkVAEWVSuGgYDMTQLmJH5nBrCsOPgcCzC4+fFt7aEfeobPl2+XrdkkKkhPuFkYXqNM73rQA==",
+      "version": "0.12.0-alpha.0-20241218-de74d9dc7",
+      "resolved": "https://registry.npmjs.org/@matter/model/-/model-0.12.0-alpha.0-20241218-de74d9dc7.tgz",
+      "integrity": "sha512-Ccn1/QuTYCaOcLVdgneG598mxlRSDPsQgLvTUOEGE0B2wdJWJP2dLICajkyO8FrilfSuMJ07t2msUJjo2UOavA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@matter/general": "0.11.9",
+        "@matter/general": "0.12.0-alpha.0-20241218-de74d9dc7",
         "@noble/curves": "^1.7.0"
       }
     },
     "node_modules/@matter/node": {
-      "version": "0.11.9",
-      "resolved": "https://registry.npmjs.org/@matter/node/-/node-0.11.9.tgz",
-      "integrity": "sha512-6Zbugz7JZnnFC45RdIwYacfLLLjpBM/PooVfR/LqcB7YdyIJRQN5o6Ws668bGTq6OEcjUAvA1tjbvA3bMMuiSw==",
+      "version": "0.12.0-alpha.0-20241218-de74d9dc7",
+      "resolved": "https://registry.npmjs.org/@matter/node/-/node-0.12.0-alpha.0-20241218-de74d9dc7.tgz",
+      "integrity": "sha512-F9pmJHgX8uUgckAPEe2HFLGcJ7um7ieiv41fXb8/uf9gtCCGQKbLMuJ60XzD/2Rz3jNRJJudSZomWuDN4SqaGA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@matter/general": "0.11.9",
-        "@matter/model": "0.11.9",
-        "@matter/protocol": "0.11.9",
-        "@matter/types": "0.11.9",
+        "@matter/general": "0.12.0-alpha.0-20241218-de74d9dc7",
+        "@matter/model": "0.12.0-alpha.0-20241218-de74d9dc7",
+        "@matter/protocol": "0.12.0-alpha.0-20241218-de74d9dc7",
+        "@matter/types": "0.12.0-alpha.0-20241218-de74d9dc7",
         "@noble/curves": "^1.7.0"
       }
     },
     "node_modules/@matter/nodejs": {
-      "version": "0.11.9",
-      "resolved": "https://registry.npmjs.org/@matter/nodejs/-/nodejs-0.11.9.tgz",
-      "integrity": "sha512-NJR2lKElalnjljl+KXgmXcLrdoaK4MH/BA57RYJ2KC3e5ZD+oxhFXfIxCUm37p7anlvv6GcK9ELkJyNaB0zg8A==",
+      "version": "0.12.0-alpha.0-20241218-de74d9dc7",
+      "resolved": "https://registry.npmjs.org/@matter/nodejs/-/nodejs-0.12.0-alpha.0-20241218-de74d9dc7.tgz",
+      "integrity": "sha512-1nIfqg7VMJ6KOIemVqWWRYOg8DdsReZL65YGmS2wS5fsDyHv73eMNI/XBApnOkjWZYBP9vMUucx1E9lOhigt0Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@matter/general": "0.11.9",
-        "@matter/node": "0.11.9",
-        "@matter/protocol": "0.11.9",
-        "@matter/types": "0.11.9",
+        "@matter/general": "0.12.0-alpha.0-20241218-de74d9dc7",
+        "@matter/node": "0.12.0-alpha.0-20241218-de74d9dc7",
+        "@matter/protocol": "0.12.0-alpha.0-20241218-de74d9dc7",
+        "@matter/types": "0.12.0-alpha.0-20241218-de74d9dc7",
         "node-localstorage": "^3.0.5"
       },
       "engines": {
@@ -1066,15 +1066,15 @@
       }
     },
     "node_modules/@matter/nodejs-ble": {
-      "version": "0.11.9",
-      "resolved": "https://registry.npmjs.org/@matter/nodejs-ble/-/nodejs-ble-0.11.9.tgz",
-      "integrity": "sha512-J2zNBya2nJY5uviUmooDbOI1zUaF3jt/92kqzhRjHHajRnMMw2DRYYXVUdnnfWxQtyKTGFzjUWLau/VAB9xnew==",
+      "version": "0.12.0-alpha.0-20241218-de74d9dc7",
+      "resolved": "https://registry.npmjs.org/@matter/nodejs-ble/-/nodejs-ble-0.12.0-alpha.0-20241218-de74d9dc7.tgz",
+      "integrity": "sha512-GihaDuBAUhkGKZBWGO+8eXyQo/et3LB3+o8x4CfeC+4NazGFMNMyBo2Pr7okPBBpnYzUf4J1Hy2aphy22F3qwQ==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
-        "@matter/general": "0.11.9",
-        "@matter/protocol": "0.11.9",
-        "@matter/types": "0.11.9"
+        "@matter/general": "0.12.0-alpha.0-20241218-de74d9dc7",
+        "@matter/protocol": "0.12.0-alpha.0-20241218-de74d9dc7",
+        "@matter/types": "0.12.0-alpha.0-20241218-de74d9dc7"
       },
       "engines": {
         "node": ">=18.0.0"
@@ -1085,25 +1085,25 @@
       }
     },
     "node_modules/@matter/protocol": {
-      "version": "0.11.9",
-      "resolved": "https://registry.npmjs.org/@matter/protocol/-/protocol-0.11.9.tgz",
-      "integrity": "sha512-AJ+1IqG8ISiZIvt4ltvSOxP+2+5wojR/1ZKjD+Wt1DdzwJA6Byhg7BnstwveZM6vl6HnQ+ZJz71RKgzhBaZR1g==",
+      "version": "0.12.0-alpha.0-20241218-de74d9dc7",
+      "resolved": "https://registry.npmjs.org/@matter/protocol/-/protocol-0.12.0-alpha.0-20241218-de74d9dc7.tgz",
+      "integrity": "sha512-r9ld6LdYGDw6EDT/Pi351E8csYDW/nB+vMoLzo3O0yW4Srycu8tzKSj33ZfudL0nnizePAFvkkLIhc182NhuYg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@matter/general": "0.11.9",
-        "@matter/model": "0.11.9",
-        "@matter/types": "0.11.9",
+        "@matter/general": "0.12.0-alpha.0-20241218-de74d9dc7",
+        "@matter/model": "0.12.0-alpha.0-20241218-de74d9dc7",
+        "@matter/types": "0.12.0-alpha.0-20241218-de74d9dc7",
         "@noble/curves": "^1.7.0"
       }
     },
     "node_modules/@matter/types": {
-      "version": "0.11.9",
-      "resolved": "https://registry.npmjs.org/@matter/types/-/types-0.11.9.tgz",
-      "integrity": "sha512-TcPVAXlfON84Uz6JeWYlc613GqXAHeh26mraLHq3dhbGyOOVJ25HpZTFN0q/IvDrRlyI8eOihAgk4iEMvihlnA==",
+      "version": "0.12.0-alpha.0-20241218-de74d9dc7",
+      "resolved": "https://registry.npmjs.org/@matter/types/-/types-0.12.0-alpha.0-20241218-de74d9dc7.tgz",
+      "integrity": "sha512-3PkNVbEU8i6MyQO8/e7SE9xVkuBIVJMKGqfSnDeAGPTfPnbYdA6B2tKWqdBiMwbFUE+HH1CFt4MznczsYur0+A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@matter/general": "0.11.9",
-        "@matter/model": "0.11.9",
+        "@matter/general": "0.12.0-alpha.0-20241218-de74d9dc7",
+        "@matter/model": "0.12.0-alpha.0-20241218-de74d9dc7",
         "@noble/curves": "^1.7.0"
       }
     },
@@ -1266,16 +1266,16 @@
       }
     },
     "node_modules/@project-chip/matter.js": {
-      "version": "0.11.9",
-      "resolved": "https://registry.npmjs.org/@project-chip/matter.js/-/matter.js-0.11.9.tgz",
-      "integrity": "sha512-r0ZXAdq2lB5w7pxkVjr/huo9hLeahUJIIxuJraXa980v67U8JNAzOOtrGboxvfgceCvDdWD40AD/1SRNnBF3gw==",
+      "version": "0.12.0-alpha.0-20241218-de74d9dc7",
+      "resolved": "https://registry.npmjs.org/@project-chip/matter.js/-/matter.js-0.12.0-alpha.0-20241218-de74d9dc7.tgz",
+      "integrity": "sha512-qZYbDx4H13p0RXGn8t0qHLTndMo53sWjL+rJ1wKBXSuCykVSq9V7Kb3ub2mXOxlreLjqYz9swDWndJlOlWVprA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@matter/general": "0.11.9",
-        "@matter/model": "0.11.9",
-        "@matter/node": "0.11.9",
-        "@matter/protocol": "0.11.9",
-        "@matter/types": "0.11.9",
+        "@matter/general": "0.12.0-alpha.0-20241218-de74d9dc7",
+        "@matter/model": "0.12.0-alpha.0-20241218-de74d9dc7",
+        "@matter/node": "0.12.0-alpha.0-20241218-de74d9dc7",
+        "@matter/protocol": "0.12.0-alpha.0-20241218-de74d9dc7",
+        "@matter/types": "0.12.0-alpha.0-20241218-de74d9dc7",
         "@noble/curves": "^1.7.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -23,16 +23,16 @@
     "url": "https://github.com/ioBroker/ioBroker.matter"
   },
   "optionalDependencies": {
-    "@matter/nodejs-ble": "0.11.9"
+    "@matter/nodejs-ble": "0.12.0-alpha.0-20241218-de74d9dc7"
   },
   "dependencies": {
     "@iobroker/adapter-core": "^3.2.3",
     "@iobroker/i18n": "^0.3.1",
     "@iobroker/dm-utils": "^0.6.11",
     "@iobroker/type-detector": "^4.1.1",
-    "@matter/main": "0.11.9",
-    "@matter/nodejs": "0.11.9",
-    "@project-chip/matter.js": "0.11.9",
+    "@matter/main": "0.12.0-alpha.0-20241218-de74d9dc7",
+    "@matter/nodejs": "0.12.0-alpha.0-20241218-de74d9dc7",
+    "@project-chip/matter.js": "0.12.0-alpha.0-20241218-de74d9dc7",
     "axios": "^1.7.9",
     "jsonwebtoken": "^9.0.2"
   },

--- a/src-admin/package-lock.json
+++ b/src-admin/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "iobroker.matter",
-    "version": "0.2.7",
+    "version": "0.2.8",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "iobroker.matter",
-            "version": "0.2.7",
+            "version": "0.2.8",
             "dependencies": {
                 "@foxriver76/iob-component-lib": "^0.2.0",
                 "@iobroker/adapter-react-v5": "^7.4.4",

--- a/src/lib/DeviceManagement.ts
+++ b/src/lib/DeviceManagement.ts
@@ -628,7 +628,7 @@ class MatterAdapterDeviceManagement extends DeviceManagement<MatterAdapter> {
             return { error: 'Device not found' };
         }
 
-        const schema = convertDataToJsonConfig(device.getDeviceDetails());
+        const schema = convertDataToJsonConfig(await device.getDeviceDetails());
 
         return { id, schema, data: {} };
     }

--- a/src/lib/JsonConfigUtils.ts
+++ b/src/lib/JsonConfigUtils.ts
@@ -39,6 +39,14 @@ export function convertDataToJsonConfig(data: StructuredJsonFormData): JsonFormS
                 };
                 continue;
             }
+            if (subKey.startsWith('__smalltext__')) {
+                tabItems[flatKey] = {
+                    type: 'staticText',
+                    text: String(data[key][subKey]),
+                    style: { fontSize: 10, fontStyle: 'italic' },
+                };
+                continue;
+            }
             if (subKey.startsWith('__divider__')) {
                 tabItems[flatKey] = {
                     type: 'divider',

--- a/src/lib/devices/ButtonSensor.ts
+++ b/src/lib/devices/ButtonSensor.ts
@@ -43,7 +43,7 @@ class ButtonSensor extends GenericDevice {
     }
 
     hasPressLong(): boolean {
-        return this.propertyNames.includes(PropertyType.PressLong);
+        return !!this.#setPressLongState;
     }
 
     getPressLong(): boolean | undefined {

--- a/src/lib/devices/Ct.ts
+++ b/src/lib/devices/Ct.ts
@@ -3,13 +3,13 @@ import ElectricityDataDevice from './ElectricityDataDevice';
 import { type DetectedDevice, type DeviceOptions, StateAccessType } from './GenericDevice';
 
 class Ct extends ElectricityDataDevice {
-    #dimmer?: DeviceStateObject<number>;
-    #brightness?: DeviceStateObject<number>;
-    #saturation?: DeviceStateObject<number>;
-    #temperature?: DeviceStateObject<number>;
-    #setPower?: DeviceStateObject<boolean>;
-    #getPower?: DeviceStateObject<boolean>;
-    #transitionTime?: DeviceStateObject<number>;
+    #dimmerState?: DeviceStateObject<number>;
+    #brightnessState?: DeviceStateObject<number>;
+    //#saturationState?: DeviceStateObject<number>; //Makes no sense!
+    #temperatureState?: DeviceStateObject<number>;
+    #setPowerState?: DeviceStateObject<boolean>;
+    #getPowerState?: DeviceStateObject<boolean>;
+    #transitionTimeState?: DeviceStateObject<number>;
 
     constructor(detectedDevice: DetectedDevice, adapter: ioBroker.Adapter, options?: DeviceOptions) {
         super(detectedDevice, adapter, options);
@@ -21,28 +21,29 @@ class Ct extends ElectricityDataDevice {
                     valueType: ValueType.NumberPercent,
                     accessType: StateAccessType.ReadWrite,
                     type: PropertyType.Dimmer,
-                    callback: state => (this.#dimmer = state),
+                    callback: state => (this.#dimmerState = state),
                 },
                 {
                     name: 'BRIGHTNESS',
                     valueType: ValueType.NumberPercent,
                     accessType: StateAccessType.ReadWrite,
                     type: PropertyType.Brightness,
-                    callback: state => (this.#brightness = state),
+                    callback: state => (this.#brightnessState = state),
                 },
+                /* Even if this state is defined for the device type it makes no sense on a Color Temperature Light, so ignore it
                 {
                     name: 'SATURATION',
                     valueType: ValueType.NumberPercent,
                     accessType: StateAccessType.ReadWrite,
                     type: PropertyType.Saturation,
-                    callback: state => (this.#saturation = state),
-                },
+                    callback: state => (this.#saturationState = state),
+                },*/
                 {
                     name: 'TEMPERATURE',
                     valueType: ValueType.NumberMinMax,
                     accessType: StateAccessType.ReadWrite,
                     type: PropertyType.Temperature,
-                    callback: state => (this.#temperature = state),
+                    callback: state => (this.#temperatureState = state),
                     unitConversionMap: {
                         mireds: value => Math.round(1_000_000 / value),
                     },
@@ -53,21 +54,21 @@ class Ct extends ElectricityDataDevice {
                     valueType: ValueType.Boolean,
                     accessType: StateAccessType.Read,
                     type: PropertyType.PowerActual,
-                    callback: state => (this.#getPower = state),
+                    callback: state => (this.#getPowerState = state),
                 },
                 {
                     name: 'ON',
                     valueType: ValueType.Boolean,
                     accessType: StateAccessType.ReadWrite,
                     type: PropertyType.Power,
-                    callback: state => (this.#setPower = state),
+                    callback: state => (this.#setPowerState = state),
                 },
                 {
                     name: 'TRANSITION_TIME',
                     valueType: ValueType.Number,
                     accessType: StateAccessType.ReadWrite,
                     type: PropertyType.TransitionTime,
-                    callback: state => (this.#transitionTime = state),
+                    callback: state => (this.#transitionTimeState = state),
                     unitConversionMap: {
                         // Default is ms
                         s: (value: number, toDefaultUnit: boolean): number =>
@@ -79,169 +80,168 @@ class Ct extends ElectricityDataDevice {
     }
 
     getDimmer(): number | undefined {
-        if (!this.#dimmer) {
-            if (!this.#brightness) {
+        if (!this.#dimmerState) {
+            if (!this.#brightnessState) {
                 throw new Error('Dimmer state not found');
             }
-            return this.#brightness.value;
+            return this.#brightnessState.value;
         }
-        return this.#dimmer.value;
+        return this.#dimmerState.value;
     }
 
     async updateDimmer(value: number): Promise<void> {
-        if (!this.#dimmer) {
-            if (!this.#brightness) {
+        if (!this.#dimmerState) {
+            if (!this.#brightnessState) {
                 throw new Error('Dimmer state not found');
             }
-            return this.#brightness.updateValue(value);
+            return this.#brightnessState.updateValue(value);
         }
-        await this.#dimmer.updateValue(value);
+        await this.#dimmerState.updateValue(value);
     }
 
     async setDimmer(value: number): Promise<void> {
-        if (!this.#dimmer) {
-            if (!this.#brightness) {
+        if (!this.#dimmerState) {
+            if (!this.#brightnessState) {
                 throw new Error('Dimmer state not found');
             }
-            return this.#brightness.setValue(value);
+            return this.#brightnessState.setValue(value);
         }
-        return this.#dimmer.setValue(value);
+        return this.#dimmerState.setValue(value);
     }
 
     hasDimmer(): boolean {
-        return this.propertyNames.includes(PropertyType.Dimmer) || this.propertyNames.includes(PropertyType.Brightness);
+        return !!this.#dimmerState || !!this.#brightnessState;
     }
 
     getBrightness(): number | undefined {
-        if (!this.#brightness) {
+        if (!this.#brightnessState) {
             throw new Error('Brightness state not found');
         }
-        return this.#brightness.value;
+        return this.#brightnessState.value;
     }
 
     async updateBrightness(value: number): Promise<void> {
-        if (!this.#brightness) {
+        if (!this.#brightnessState) {
             throw new Error('Brightness state not found');
         }
-        await this.#brightness.updateValue(value);
+        await this.#brightnessState.updateValue(value);
     }
 
     async setBrightness(value: number): Promise<void> {
-        if (!this.#brightness) {
+        if (!this.#brightnessState) {
             throw new Error('Brightness state not found');
         }
-        return this.#brightness.setValue(value);
+        return this.#brightnessState.setValue(value);
     }
 
+    /*
     getSaturation(): number | undefined {
-        if (!this.#saturation) {
+        if (!this.#saturationState) {
             throw new Error('Saturation state not found');
         }
-        return this.#saturation.value;
+        return this.#saturationState.value;
     }
 
     async setSaturation(value: number): Promise<void> {
-        if (!this.#saturation) {
+        if (!this.#saturationState) {
             throw new Error('Saturation state not found');
         }
-        return this.#saturation.setValue(value);
+        return this.#saturationState.setValue(value);
     }
+    */
 
     getTemperature(): number | undefined {
-        if (!this.#temperature) {
+        if (!this.#temperatureState) {
             throw new Error('Temperature state not found');
         }
-        return this.#temperature.value;
+        return this.#temperatureState.value;
     }
 
     getTemperatureMinMax(): { min: number; max: number } | null {
-        if (!this.#temperature) {
+        if (!this.#temperatureState) {
             throw new Error('Temperature state not found');
         }
-        return this.#temperature.getMinMax();
+        return this.#temperatureState.getMinMax();
     }
 
     async updateTemperature(value: number): Promise<void> {
-        if (!this.#temperature) {
+        if (!this.#temperatureState) {
             throw new Error('Temperature state not found');
         }
-        await this.#temperature.updateValue(value);
+        await this.#temperatureState.updateValue(value);
     }
 
     async setTemperature(value: number): Promise<void> {
-        if (!this.#temperature) {
+        if (!this.#temperatureState) {
             throw new Error('Temperature state not found');
         }
-        return this.#temperature.setValue(value);
+        return this.#temperatureState.setValue(value);
     }
 
     getPower(): boolean | undefined {
-        if (!this.#getPower && !this.#setPower) {
+        if (!this.#getPowerState && !this.#setPowerState) {
             throw new Error('On state not found');
         }
-        return (this.#getPower || this.#setPower)?.value;
+        return (this.#getPowerState || this.#setPowerState)?.value;
     }
 
     async setPower(value: boolean): Promise<void> {
-        if (!this.#setPower) {
+        if (!this.#setPowerState) {
             throw new Error('On state not found');
         }
-        return this.#setPower.setValue(value);
+        return this.#setPowerState.setValue(value);
     }
 
     async updatePower(value: boolean): Promise<void> {
-        if (!this.#getPower && !this.#setPower) {
+        if (!this.#getPowerState && !this.#setPowerState) {
             throw new Error('Power state not found');
         }
-        if (this.#getPower) {
-            await this.#getPower.updateValue(value);
-        }
-        if (this.#setPower) {
-            await this.#setPower.updateValue(value);
-        }
+        await this.#getPowerState?.updateValue(value);
+        await this.#setPowerState?.updateValue(value);
     }
 
     hasPower(): boolean {
-        return this.propertyNames.includes(PropertyType.Power);
+        return !!this.#getPowerState;
     }
 
     getPowerActual(): boolean | undefined {
-        if (!this.#getPower) {
+        if (!this.#getPowerState) {
             throw new Error('PowerActual state not found');
         }
-        return this.#getPower.value;
+        return this.#getPowerState.value;
     }
 
     async updatePowerActual(value: boolean): Promise<void> {
-        if (!this.#getPower) {
+        if (!this.#getPowerState) {
             throw new Error('PowerActual state not found');
         }
-        await this.#getPower.updateValue(value);
+        await this.#getPowerState.updateValue(value);
+        await this.#setPowerState?.updateValue(value);
     }
 
     hasTransitionTime(): boolean {
-        return this.propertyNames.includes(PropertyType.TransitionTime);
+        return !!this.#transitionTimeState;
     }
 
     getTransitionTime(): number | undefined {
-        if (!this.#transitionTime) {
+        if (!this.#transitionTimeState) {
             throw new Error('TransitionTime state not found');
         }
-        return this.#transitionTime.value;
+        return this.#transitionTimeState.value;
     }
 
     setTransitionTime(value: number): Promise<void> {
-        if (!this.#transitionTime) {
+        if (!this.#transitionTimeState) {
             throw new Error('TransitionTime state not found');
         }
-        return this.#transitionTime.setValue(value);
+        return this.#transitionTimeState.setValue(value);
     }
 
     updateTransitionTime(value: number): Promise<void> {
-        if (!this.#transitionTime) {
+        if (!this.#transitionTimeState) {
             throw new Error('TransitionTime state not found');
         }
-        return this.#transitionTime.updateValue(value);
+        return this.#transitionTimeState.updateValue(value);
     }
 }
 

--- a/src/lib/devices/ElectricityDataDevice.ts
+++ b/src/lib/devices/ElectricityDataDevice.ts
@@ -89,6 +89,10 @@ class ElectricityDataDevice extends GenericDevice {
         );
     }
 
+    hasElectricPower(): boolean {
+        return !!this.#getElectricPowerState;
+    }
+
     getElectricPower(): number | undefined {
         if (!this.#getElectricPowerState) {
             throw new Error('Power state not found');
@@ -101,6 +105,10 @@ class ElectricityDataDevice extends GenericDevice {
             throw new Error('Power state not found');
         }
         return this.#getElectricPowerState.updateValue(value);
+    }
+
+    hasCurrent(): boolean {
+        return !!this.#getCurrentState;
     }
 
     getCurrent(): number | undefined {
@@ -117,6 +125,10 @@ class ElectricityDataDevice extends GenericDevice {
         return this.#getCurrentState.updateValue(value);
     }
 
+    hasVoltage(): boolean {
+        return !!this.#getVoltageState;
+    }
+
     getVoltage(): number | undefined {
         if (!this.#getVoltageState) {
             throw new Error('Voltage state not found');
@@ -131,6 +143,10 @@ class ElectricityDataDevice extends GenericDevice {
         return this.#getVoltageState.updateValue(value);
     }
 
+    hasConsumption(): boolean {
+        return !!this.#getConsumptionState;
+    }
+
     getConsumption(): number | undefined {
         if (!this.#getConsumptionState) {
             throw new Error('Consumption state not found');
@@ -143,6 +159,10 @@ class ElectricityDataDevice extends GenericDevice {
             throw new Error('Consumption state not found');
         }
         return this.#getConsumptionState.updateValue(value);
+    }
+
+    hasFrequency(): boolean {
+        return !!this.#getFrequencyState;
     }
 
     getFrequency(): number | undefined {

--- a/src/lib/devices/GenericDevice.ts
+++ b/src/lib/devices/GenericDevice.ts
@@ -659,11 +659,10 @@ abstract class GenericDevice {
             };
             if (includeObjectIds) {
                 if (write !== read && write && read) {
-                    states[`__text__${name}`] = `Write: ${write}, Read: ${read}`;
+                    states[`__smalltext__${name}`] = `Write: ${write}, Read: ${read}`;
                 } else {
-                    states[`__text__${name}`] = write ?? read;
+                    states[`__smalltext__${name}`] = write ?? read;
                 }
-                states[`__divider__${name}`] = true;
             }
         });
 

--- a/src/lib/devices/Humidity.ts
+++ b/src/lib/devices/Humidity.ts
@@ -2,7 +2,7 @@ import { type DeviceStateObject, PropertyType, ValueType } from './DeviceStateOb
 import GenericDevice, { type DetectedDevice, type DeviceOptions, StateAccessType } from './GenericDevice';
 
 class Humidity extends GenericDevice {
-    #getValueState?: DeviceStateObject<number>;
+    #getHumidityState?: DeviceStateObject<number>;
 
     constructor(detectedDevice: DetectedDevice, adapter: ioBroker.Adapter, options?: DeviceOptions) {
         super(detectedDevice, adapter, options);
@@ -14,24 +14,24 @@ class Humidity extends GenericDevice {
                     valueType: ValueType.NumberPercent,
                     accessType: StateAccessType.Read,
                     type: PropertyType.Humidity,
-                    callback: state => (this.#getValueState = state),
+                    callback: state => (this.#getHumidityState = state),
                 },
             ]),
         );
     }
 
     getHumidity(): number | undefined {
-        if (!this.#getValueState) {
+        if (!this.#getHumidityState) {
             throw new Error('Value state not found');
         }
-        return this.#getValueState.value;
+        return this.#getHumidityState.value;
     }
 
     async updateHumidity(value: number): Promise<void> {
-        if (!this.#getValueState) {
+        if (!this.#getHumidityState) {
             throw new Error('Value state not found');
         }
-        await this.#getValueState.updateValue(value);
+        await this.#getHumidityState.updateValue(value);
     }
 }
 

--- a/src/lib/devices/Light.ts
+++ b/src/lib/devices/Light.ts
@@ -41,12 +41,8 @@ class Light extends ElectricityDataDevice {
         if (!this.#getPowerState && !this.#setPowerState) {
             throw new Error('On state not found');
         }
-        if (this.#getPowerState) {
-            await this.#getPowerState.updateValue(value);
-        }
-        if (this.#setPowerState) {
-            await this.#setPowerState.updateValue(value);
-        }
+        await this.#getPowerState?.updateValue(value);
+        await this.#setPowerState?.updateValue(value);
     }
 
     async setPower(value: boolean): Promise<void> {
@@ -68,6 +64,7 @@ class Light extends ElectricityDataDevice {
             throw new Error('On Actual state not found');
         }
         await this.#getPowerState.updateValue(value);
+        await this.#setPowerState?.updateValue(value);
     }
 }
 

--- a/src/lib/devices/Lock.ts
+++ b/src/lib/devices/Lock.ts
@@ -75,6 +75,7 @@ class Lock extends GenericDevice {
             throw new Error('Level state not found');
         }
         await this.#getLockState.updateValue(value);
+        await this.#setLockState?.updateValue(value);
     }
 
     async setOpen(): Promise<void> {
@@ -85,7 +86,7 @@ class Lock extends GenericDevice {
     }
 
     hasOpen(): boolean {
-        return this.propertyNames.includes(PropertyType.Open);
+        return !!this.#setOpenState;
     }
 }
 

--- a/src/lib/devices/Motion.ts
+++ b/src/lib/devices/Motion.ts
@@ -43,7 +43,7 @@ class Motion extends GenericDevice {
     }
 
     hasBrightness(): boolean {
-        return this.propertyNames.includes(PropertyType.Brightness);
+        return !!this.#getBrightnessState;
     }
 
     getBrightness(): number | undefined {

--- a/src/lib/devices/Socket.ts
+++ b/src/lib/devices/Socket.ts
@@ -37,16 +37,19 @@ class Socket extends ElectricityDataDevice {
         return (this.#getPowerState || this.#setPowerState)?.value;
     }
 
+    async setPower(value: boolean): Promise<void> {
+        if (!this.#setPowerState) {
+            throw new Error('Level state not found');
+        }
+        await this.#setPowerState.setValue(value);
+    }
+
     async updatePower(value: boolean): Promise<void> {
         if (!this.#getPowerState && !this.#setPowerState) {
             throw new Error('Level state not found');
         }
-        if (this.#getPowerState) {
-            await this.#getPowerState.updateValue(value);
-        }
-        if (this.#setPowerState) {
-            await this.#setPowerState.updateValue(value);
-        }
+        await this.#getPowerState?.updateValue(value);
+        await this.#setPowerState?.updateValue(value);
     }
 
     getPowerActual(): boolean | undefined {
@@ -61,13 +64,7 @@ class Socket extends ElectricityDataDevice {
             throw new Error('Level state not found');
         }
         await this.#getPowerState.updateValue(value);
-    }
-
-    async setPower(value: boolean): Promise<void> {
-        if (!this.#setPowerState) {
-            throw new Error('Level state not found');
-        }
-        await this.#setPowerState.setValue(value);
+        await this.#setPowerState?.updateValue(value);
     }
 }
 

--- a/src/lib/devices/Temperature.ts
+++ b/src/lib/devices/Temperature.ts
@@ -31,10 +31,6 @@ class Temperature extends GenericDevice {
         );
     }
 
-    hasHumidity(): boolean {
-        return this.propertyNames.includes(PropertyType.Humidity);
-    }
-
     getTemperature(): number | undefined {
         if (!this.#getTemperatureState) {
             throw new Error('Value state not found');
@@ -47,6 +43,10 @@ class Temperature extends GenericDevice {
             throw new Error('Value state not found');
         }
         await this.#getTemperatureState.updateValue(value);
+    }
+
+    hasHumidity(): boolean {
+        return !!this.#getHumidityState;
     }
 
     getHumidity(): number | undefined {

--- a/src/main.ts
+++ b/src/main.ts
@@ -1353,7 +1353,7 @@ export class MatterAdapter extends utils.Adapter {
     async deleteBridgeOrDevice(type: 'bridge' | 'device', id: string, uuid: string): Promise<void> {
         await this.stopBridgeOrDevice(type, id);
         const storage = new IoBrokerObjectStorage(this, uuid);
-        await storage.clearAll();
+        await storage.clear();
     }
 
     getGenericErrorDetails(

--- a/src/matter/behaviors/PowerSourceServer.ts
+++ b/src/matter/behaviors/PowerSourceServer.ts
@@ -16,6 +16,5 @@ export class BatteryPowerSourceServer extends BatteryPowerSource {
             endpointNumbers.push(number);
         });
         this.state.endpointList = endpointNumbers;
-        console.log(`Endpoint numbers set for PowerSource on : ${this.endpoint.id}`, endpointNumbers);
     }
 }

--- a/src/matter/to-iobroker/GenericDeviceToIoBroker.ts
+++ b/src/matter/to-iobroker/GenericDeviceToIoBroker.ts
@@ -147,10 +147,9 @@ export abstract class GenericDeviceToIoBroker {
     }
 
     #enablePowerSourceStates(): void {
-        const endpointId = this.appEndpoint.getNumber();
-
         const powerSource = this.appEndpoint.getClusterClient(PowerSource.Complete);
-        if (powerSource !== undefined && powerSource.supportedFeatures.battery) {
+        if (powerSource !== undefined) {
+            const endpointId = this.appEndpoint.getNumber();
             this.enableDeviceTypeStateForAttribute(PropertyType.LowBattery, {
                 endpointId,
                 clusterId: PowerSource.Cluster.id,
@@ -163,7 +162,7 @@ export abstract class GenericDeviceToIoBroker {
                 attributeName: 'batPercentRemaining',
                 convertValue: value => Math.round(value / 2),
             });
-        } else if (powerSource === undefined) {
+        } else {
             const rootPowerSource = this.#rootEndpoint.getClusterClient(PowerSource.Complete);
             if (rootPowerSource !== undefined && rootPowerSource.supportedFeatures.battery) {
                 this.enableDeviceTypeStateForAttribute(PropertyType.LowBattery, {

--- a/src/matter/to-iobroker/LightSensorToIoBroker.ts
+++ b/src/matter/to-iobroker/LightSensorToIoBroker.ts
@@ -40,7 +40,7 @@ export class LightSensorToIoBroker extends GenericDeviceToIoBroker {
     }
 
     protected enableDeviceTypeStates(): DeviceOptions {
-        this.enableDeviceTypeStateForAttribute(PropertyType.Motion, {
+        this.enableDeviceTypeStateForAttribute(PropertyType.Brightness, {
             endpointId: this.appEndpoint.getNumber(),
             clusterId: IlluminanceMeasurement.Cluster.id,
             attributeName: 'measuredValue',

--- a/src/matter/to-iobroker/UtilityOnlyToIoBroker.ts
+++ b/src/matter/to-iobroker/UtilityOnlyToIoBroker.ts
@@ -47,8 +47,8 @@ export class UtilityOnlyToIoBroker extends GenericElectricityDataDeviceToIoBroke
         return this.#ioBrokerDevice;
     }
 
-    override getDeviceDetails(): StructuredJsonFormData {
-        const details = super.getDeviceDetails();
+    override async getDeviceDetails(): Promise<StructuredJsonFormData> {
+        const details = await super.getDeviceDetails();
 
         const unsupportedInfo = {
             __header__UnsupportedNotice: 'This Device type is not automatically mapped to ioBroker!',


### PR DESCRIPTION
* When Get and set states are separated then also update set state with new values
* Node details dialog in controller now exposes some more Battery information
* Also exposes the battery states when features are set wrong on the device
* Fixes LightSensor state mapping
* Prevents errors when only some energy states exist
* Uses the IP provided by Android when commissioning devices if possible
* Restructure discovery to run in background and not block the UI
* Exposes States for Enums for Matter nodes
* Prevent storage to delete wrong data when a node gets removed