### PR TITLE
feat(network): sync Thread/WiFi visualization with matterjs-server (OTBR, icons, details)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,7 @@ Built on `@matter/main` (matter.js) library and follows the ioBroker adapter dev
 ioBroker.matter/
 ├── src/                      # Backend TypeScript source
 │   ├── main.ts              # Main adapter entry point (MatterAdapter class)
-│   ├── ioBrokerStorageTypes.ts  # Type definitions for ioBroker storage
+│   ├── ioBrokerTypes.ts  # Shared backend type definitions (config, descriptions, network data)
 │   ├── lib/                 # Core library code
 │   │   ├── devices/         # ioBroker device type implementations
 │   │   ├── DeviceFactory.ts # Factory for creating device instances
@@ -240,7 +240,7 @@ Verified via `iobroker.pro` API in `checkLicense()`.
 1. **Never import from `src-admin/` in backend code** - The backend tsconfig does not include src-admin
 2. **Never import from `src/` in frontend code** - The frontend tsconfig does not include src
 3. **Shared types must be duplicated** - If both projects need the same types, define them in both:
-   - Backend types: `src/ioBrokerStorageTypes.ts`
+   - Backend types: `src/ioBrokerTypes.ts`
    - Frontend types: `src-admin/src/types.d.ts`
 4. **Keep type definitions in sync manually** - When modifying shared types, update both files
 
@@ -255,8 +255,8 @@ Cross-project imports will:
 
 | Type Category | Backend Location | Frontend Location |
 |---------------|------------------|-------------------|
-| Config types | `src/ioBrokerStorageTypes.ts` | `src-admin/src/types.d.ts` |
-| Network graph types | `src/ioBrokerStorageTypes.ts` | `src-admin/src/types.d.ts` |
+| Config types | `src/ioBrokerTypes.ts` | `src-admin/src/types.d.ts` |
+| Network graph types | `src/ioBrokerTypes.ts` | `src-admin/src/types.d.ts` |
 | GUI message types | N/A (backend uses inline) | `src-admin/src/types.d.ts` |
 
 ## Development Tips
@@ -306,6 +306,6 @@ Set `debug: true` in adapter config to enable verbose matter.js logging.
 | `src/matter/to-iobroker/ioBrokerFactory.ts` | Creates ioBroker mappings for controller |
 | `src-admin/src/App.tsx` | Main React application |
 | `src-admin/src/components/ConfigHandler.tsx` | Config sync between UI and objects |
-| `src/ioBrokerStorageTypes.ts` | Backend TypeScript types |
+| `src/ioBrokerTypes.ts` | Backend TypeScript types |
 | `src-admin/src/types.d.ts` | Frontend TypeScript types |
 | `io-package.json` | ioBroker adapter metadata |

--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ Tests are located in the `test/` directory and use ts-node for direct TypeScript
 ## Changelog
 
 ### **WORK IN PROGRESS**
+* (@Apollon77) Enhanced Thread/WiFi network visualization: OTBR mDNS discovery, device-type and Thread role icons, border-router details and markers, LQI link colors, hide/search options and localized labels
 * (@Apollon77) Ignores invalid min/max/step settings in linked objects
 
 ### 1.1.1 (2026-06-22)

--- a/src-admin/package-lock.json
+++ b/src-admin/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "iobroker.matter",
-    "version": "1.1.0",
+    "version": "1.1.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "iobroker.matter",
-            "version": "1.1.0",
+            "version": "1.1.1",
             "dependencies": {
                 "@emotion/react": "^11.14.0",
                 "@emotion/styled": "^11.14.1",
@@ -14,6 +14,7 @@
                 "@iobroker/adapter-react-v5": "^8.2.13",
                 "@iobroker/dm-gui-components": "^9.1.7",
                 "@iobroker/type-detector": "^5.0.13",
+                "@mdi/js": "^7.4.47",
                 "@types/react-dom": "^18.3.7",
                 "@vitejs/plugin-react": "^5.2.0",
                 "@yudiel/react-qr-scanner": "^2.6.0",
@@ -1302,6 +1303,12 @@
                 "@jridgewell/resolve-uri": "^3.1.0",
                 "@jridgewell/sourcemap-codec": "^1.4.14"
             }
+        },
+        "node_modules/@mdi/js": {
+            "version": "7.4.47",
+            "resolved": "https://registry.npmjs.org/@mdi/js/-/js-7.4.47.tgz",
+            "integrity": "sha512-KPnNOtm5i2pMabqZxpUz7iQf+mfrYZyKCZ8QNz85czgEt7cuHcGorWfdzUMWYA0SD+a6Hn4FmJ+YhzzzjkTZrQ==",
+            "license": "Apache-2.0"
         },
         "node_modules/@module-federation/error-codes": {
             "version": "2.5.1",

--- a/src-admin/package.json
+++ b/src-admin/package.json
@@ -9,6 +9,7 @@
         "@iobroker/adapter-react-v5": "^8.2.13",
         "@iobroker/dm-gui-components": "^9.1.7",
         "@iobroker/type-detector": "^5.0.13",
+        "@mdi/js": "^7.4.47",
         "@types/react-dom": "^18.3.7",
         "@vitejs/plugin-react": "^5.2.0",
         "@yudiel/react-qr-scanner": "^2.6.0",

--- a/src-admin/src/App.tsx
+++ b/src-admin/src/App.tsx
@@ -634,7 +634,7 @@ class App extends GenericApp<GenericAppProps, AppState> {
                     await this.onChanged(config);
                 }}
                 showToast={(text: string) => this.showToast(text)}
-                checkLicenseOnAdd={(type: 'addBridge' | 'addDevice' | 'addDeviceToBridge', matter: MatterConfig) =>
+                checkLicenseOnAdd={(type: 'addBridge' | 'addDevice' | 'addDeviceToBridge', matter?: MatterConfig) =>
                     this.checkLicenseOnAdd(type, matter)
                 }
                 identifyUuids={this.state.identifyUuids}
@@ -674,7 +674,7 @@ class App extends GenericApp<GenericAppProps, AppState> {
                     await this.onChanged(config);
                 }}
                 showToast={(text: string) => this.showToast(text)}
-                checkLicenseOnAdd={(matter: MatterConfig) => this.checkLicenseOnAdd('addDevice', matter)}
+                checkLicenseOnAdd={(matter?: MatterConfig) => this.checkLicenseOnAdd('addDevice', matter)}
                 identifyUuids={this.state.identifyUuids}
                 expertMode={this.state.localExpertMode}
                 setExpertMode={localExpertMode => this.setLocalExpertMode(localExpertMode)}
@@ -1020,27 +1020,27 @@ class App extends GenericApp<GenericAppProps, AppState> {
                                     );
                                 }}
                                 scrollButtons="auto"
-                                sx={{ '& .MuiTabs-indicator': styles.indicator }}
+                                sx={{ '& .MuiTabs-indicator': styles.indicator(this.state.theme) }}
                             >
                                 {this.isTab ? null : (
                                     <Tab
-                                        sx={{ '&.Mui-selected': styles.selected }}
+                                        sx={{ '&.Mui-selected': styles.selected(this.state.theme) }}
                                         label={I18n.t('General')}
                                         value="options"
                                     />
                                 )}
                                 <Tab
-                                    sx={{ '&.Mui-selected': styles.selected }}
+                                    sx={{ '&.Mui-selected': styles.selected(this.state.theme) }}
                                     label={I18n.t('Controller')}
                                     value="controller"
                                 />
                                 <Tab
-                                    sx={{ '&.Mui-selected': styles.selected }}
+                                    sx={{ '&.Mui-selected': styles.selected(this.state.theme) }}
                                     label={I18n.t('Bridges')}
                                     value="bridges"
                                 />
                                 <Tab
-                                    sx={{ '&.Mui-selected': styles.selected }}
+                                    sx={{ '&.Mui-selected': styles.selected(this.state.theme) }}
                                     label={I18n.t('Devices')}
                                     value="devices"
                                 />

--- a/src-admin/src/Tabs/Controller.tsx
+++ b/src-admin/src/Tabs/Controller.tsx
@@ -33,7 +33,7 @@ import type { CommissionableDevice, GUIMessage, MatterConfig } from '../types';
 import { clone } from '../Utils';
 import QrCodeDialog from '../components/QrCodeDialog';
 import DiscoveredDevicesDialog from '../components/DiscoveredDevicesDialog';
-import { NetworkGraphDialog, type NetworkGraphData } from '../components/network';
+import { NetworkGraphDialog, type NetworkGraphData, type BorderRouterEntry } from '../components/network';
 
 /**
  * Validates that an object conforms to the NetworkGraphData structure
@@ -145,6 +145,8 @@ interface ComponentState {
     networkGraphData: NetworkGraphData | null;
     /** Network graph loading error */
     networkGraphError: string | null;
+    /** mDNS-discovered Thread Border Routers */
+    networkBorderRouters: BorderRouterEntry[];
 }
 
 class Controller extends Component<ComponentProps, ComponentState> {
@@ -169,6 +171,7 @@ class Controller extends Component<ComponentProps, ComponentState> {
             networkGraphDialogType: null,
             networkGraphData: null,
             networkGraphError: null,
+            networkBorderRouters: [],
         };
     }
 
@@ -571,6 +574,21 @@ class Controller extends Component<ComponentProps, ComponentState> {
             console.error('Failed to load network graph data:', error);
             this.setState({ networkGraphError: errorMessage });
         }
+
+        // Thread Border Routers are discovered independently via mDNS; failure here must not
+        // block the graph (it stays usable without BR enrichment).
+        try {
+            const brResult = await this.props.socket.sendTo(
+                `matter.${this.props.instance}`,
+                'controllerThreadBorderRouters',
+                {},
+            );
+            if (brResult?.result && Array.isArray(brResult.result)) {
+                this.setState({ networkBorderRouters: brResult.result as BorderRouterEntry[] });
+            }
+        } catch (error) {
+            console.error('Failed to load Thread border routers:', error);
+        }
     };
 
     /**
@@ -605,6 +623,7 @@ class Controller extends Component<ComponentProps, ComponentState> {
                 onUpdateConnections={this.updateNetworkConnections}
                 darkMode={this.props.themeType === 'dark'}
                 networkType={this.state.networkGraphDialogType}
+                borderRouters={this.state.networkBorderRouters}
             />
         );
     }
@@ -637,7 +656,7 @@ class Controller extends Component<ComponentProps, ComponentState> {
                             });
                         } else {
                             window.alert(I18n.t('Connected'));
-                            this.refDeviceManager.current?.loadData();
+                            void this.refDeviceManager.current?.loadAllData();
                         }
                     } else {
                         this.setState({ showQrCodeDialog: false });
@@ -658,7 +677,7 @@ class Controller extends Component<ComponentProps, ComponentState> {
                 registerDiscoveryMessageHandler={(handler: null | ((device: CommissionableDevice) => void)): void => {
                     this.onDiscoveryMessageHandler = handler;
                 }}
-                triggerDeviceManagerLoad={() => this.refDeviceManager.current?.loadData()}
+                triggerDeviceManagerLoad={() => this.refDeviceManager.current?.loadAllData()}
                 onClose={(): void => this.setState({ showDiscoveryDialog: false })}
                 ble={!!this.props.matter.controller.ble}
                 instance={this.props.instance}

--- a/src-admin/src/components/network/NetworkGraphDialog.tsx
+++ b/src-admin/src/components/network/NetworkGraphDialog.tsx
@@ -17,6 +17,12 @@ import {
     CircularProgress,
     Paper,
     Divider,
+    Menu,
+    MenuItem,
+    Checkbox,
+    ListItemText,
+    TextField,
+    InputAdornment,
 } from '@mui/material';
 import {
     Close as CloseIcon,
@@ -27,17 +33,21 @@ import {
     ZoomOut as ZoomOutIcon,
     Pause as PauseIcon,
     PlayArrow as PlayArrowIcon,
+    FilterList as FilterListIcon,
+    Search as SearchIcon,
 } from '@mui/icons-material';
 
-import type { NetworkGraphData, NetworkNodeData } from './NetworkTypes';
+import type { NetworkGraphData, NetworkNodeData, BorderRouterEntry } from './NetworkTypes';
 import {
     SIGNAL_COLORS,
     categorizeNodes,
     formatNodeIdHex,
+    formatThreadVersion,
     getThreadRoleName,
     getWiFiSecurityTypeName,
     getWiFiVersionName,
     parseExtendedAddressToHex,
+    parseBssidToMac,
     buildExtAddrMap,
     buildRloc16Map,
     buildThreadConnections,
@@ -60,6 +70,8 @@ interface NetworkGraphDialogProps {
     darkMode: boolean;
     /** Which network type to display */
     networkType: 'thread' | 'wifi';
+    /** mDNS-discovered Thread Border Routers (controllerThreadBorderRouters) */
+    borderRouters?: BorderRouterEntry[];
 }
 
 interface NetworkGraphDialogState {
@@ -67,10 +79,20 @@ interface NetworkGraphDialogState {
     selectedNodeId: string | null;
     updateDialogOpen: boolean;
     physicsEnabled: boolean;
+    filterAnchorEl: HTMLElement | null;
+    hideOfflineNodes: boolean;
+    hideWeakSignalEdges: boolean;
+    hideMediumSignalEdges: boolean;
+    hideStrongSignalEdges: boolean;
+    searchQuery: string;
 }
 
 class NetworkGraphDialog extends React.Component<NetworkGraphDialogProps, NetworkGraphDialogState> {
     private graphRef = React.createRef<ThreadGraph | WiFiGraph>();
+
+    /** Cached BR map; rebuilt only when the source array reference changes. */
+    private brMapSource: BorderRouterEntry[] | undefined;
+    private brMap: ReadonlyMap<string, BorderRouterEntry> = new Map();
 
     constructor(props: NetworkGraphDialogProps) {
         super(props);
@@ -79,8 +101,36 @@ class NetworkGraphDialog extends React.Component<NetworkGraphDialogProps, Networ
             selectedNodeId: null,
             updateDialogOpen: false,
             physicsEnabled: true,
+            filterAnchorEl: null,
+            hideOfflineNodes: false,
+            hideWeakSignalEdges: false,
+            hideMediumSignalEdges: false,
+            hideStrongSignalEdges: false,
+            searchQuery: '',
         };
     }
+
+    private getBorderRoutersMap(): ReadonlyMap<string, BorderRouterEntry> {
+        if (this.props.borderRouters !== this.brMapSource) {
+            this.brMapSource = this.props.borderRouters;
+            const map = new Map<string, BorderRouterEntry>();
+            for (const br of this.props.borderRouters ?? []) {
+                map.set(br.extAddressHex.toUpperCase(), br);
+            }
+            this.brMap = map;
+        }
+        return this.brMap;
+    }
+
+    handleSearch = (): void => {
+        const graph = this.graphRef.current;
+        if (graph instanceof ThreadGraph) {
+            const matchId = graph.findNodeBySearch(this.state.searchQuery);
+            if (matchId) {
+                this.setState({ selectedNodeId: matchId });
+            }
+        }
+    };
 
     componentDidMount(): void {
         // Load data when dialog opens
@@ -266,9 +316,9 @@ class NetworkGraphDialog extends React.Component<NetworkGraphDialogProps, Networ
                     {I18n.t('Connections')} ({connections.length})
                 </Typography>
                 <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1, maxHeight: 200, overflowY: 'auto' }}>
-                    {connections.map((conn, index) => (
+                    {connections.map(conn => (
                         <Box
-                            key={index}
+                            key={conn.connectedNodeId}
                             sx={{
                                 display: 'flex',
                                 alignItems: 'flex-start',
@@ -397,11 +447,11 @@ class NetworkGraphDialog extends React.Component<NetworkGraphDialogProps, Networ
                             {I18n.t('Thread Roles')}:
                         </Typography>
                         <Box sx={{ display: 'flex', gap: 1, alignItems: 'center' }}>
-                            <Box sx={{ width: 10, height: 10, borderRadius: '50%', backgroundColor: '#9C27B0' }} />
+                            <Box sx={{ width: 10, height: 10, borderRadius: '50%', backgroundColor: '#F9A825' }} />
                             <Typography variant="caption">{I18n.t('Leader')}</Typography>
                         </Box>
                         <Box sx={{ display: 'flex', gap: 1, alignItems: 'center' }}>
-                            <Box sx={{ width: 10, height: 10, borderRadius: '50%', backgroundColor: '#2196F3' }} />
+                            <Box sx={{ width: 10, height: 10, borderRadius: '50%', backgroundColor: '#1E88E5' }} />
                             <Typography variant="caption">{I18n.t('Router')}</Typography>
                         </Box>
                         <Box sx={{ display: 'flex', gap: 1, alignItems: 'center' }}>
@@ -409,7 +459,11 @@ class NetworkGraphDialog extends React.Component<NetworkGraphDialogProps, Networ
                             <Typography variant="caption">{I18n.t('End Device')}</Typography>
                         </Box>
                         <Box sx={{ display: 'flex', gap: 1, alignItems: 'center' }}>
-                            <Box sx={{ width: 10, height: 10, borderRadius: '50%', backgroundColor: '#FFC107' }} />
+                            <Box sx={{ width: 10, height: 10, borderRadius: '50%', backgroundColor: '#03A9F4' }} />
+                            <Typography variant="caption">{I18n.t('Border Router')}</Typography>
+                        </Box>
+                        <Box sx={{ display: 'flex', gap: 1, alignItems: 'center' }}>
+                            <Box sx={{ width: 10, height: 10, borderRadius: '50%', backgroundColor: '#FF9800' }} />
                             <Typography variant="caption">{I18n.t('Unknown Device')}</Typography>
                         </Box>
                     </>
@@ -543,6 +597,12 @@ class NetworkGraphDialog extends React.Component<NetworkGraphDialogProps, Networ
                                         <strong>{I18n.t('Channel')}:</strong> {node.thread.channel}
                                     </Typography>
                                 )}
+                                {formatThreadVersion(node.thread.threadVersion ?? null) !== null && (
+                                    <Typography variant="body2">
+                                        <strong>{I18n.t('Thread Version')}:</strong>{' '}
+                                        {formatThreadVersion(node.thread.threadVersion ?? null)}
+                                    </Typography>
+                                )}
                                 {node.thread.extendedAddress && (
                                     <Typography
                                         variant="body2"
@@ -572,6 +632,17 @@ class NetworkGraphDialog extends React.Component<NetworkGraphDialogProps, Networ
                         )}
                         {node.networkType === 'wifi' && node.wifi && (
                             <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.5 }}>
+                                {node.wifi.bssid && (
+                                    <Typography
+                                        variant="body2"
+                                        sx={{ wordBreak: 'break-all' }}
+                                    >
+                                        <strong>{I18n.t('BSSID')}:</strong>{' '}
+                                        <span style={{ fontFamily: 'monospace', fontSize: '0.85em' }}>
+                                            {parseBssidToMac(node.wifi.bssid)}
+                                        </span>
+                                    </Typography>
+                                )}
                                 {node.wifi.rssi !== null && (
                                     <Typography variant="body2">
                                         <strong>{I18n.t('RSSI')}:</strong> {node.wifi.rssi} dBm
@@ -687,6 +758,11 @@ class NetworkGraphDialog extends React.Component<NetworkGraphDialogProps, Networ
                             onNodeSelect={this.handleNodeSelect}
                             selectedNodeId={selectedNodeId}
                             onPhysicsChange={this.handlePhysicsChange}
+                            borderRouters={this.getBorderRoutersMap()}
+                            hideOfflineNodes={this.state.hideOfflineNodes}
+                            hideWeakSignalEdges={this.state.hideWeakSignalEdges}
+                            hideMediumSignalEdges={this.state.hideMediumSignalEdges}
+                            hideStrongSignalEdges={this.state.hideStrongSignalEdges}
                         />
                     ) : (
                         <WiFiGraph
@@ -717,8 +793,8 @@ class NetworkGraphDialog extends React.Component<NetworkGraphDialogProps, Networ
                 onClose={onClose}
                 maxWidth="lg"
                 fullWidth
-                PaperProps={{
-                    sx: { height: '80vh' },
+                slotProps={{
+                    paper: { sx: { height: '80vh' } },
                 }}
             >
                 <DialogTitle sx={{ display: 'flex', alignItems: 'center', gap: 1, pb: 1 }}>
@@ -728,6 +804,99 @@ class NetworkGraphDialog extends React.Component<NetworkGraphDialogProps, Networ
                     >
                         {title}
                     </Typography>
+                    {networkType === 'thread' && (
+                        <>
+                            <TextField
+                                size="small"
+                                variant="outlined"
+                                placeholder={I18n.t('Search mesh')}
+                                value={this.state.searchQuery}
+                                onChange={e => this.setState({ searchQuery: e.target.value })}
+                                onKeyDown={e => {
+                                    if (e.key === 'Enter') {
+                                        this.handleSearch();
+                                    }
+                                }}
+                                sx={{ mr: 1, width: 200 }}
+                                slotProps={{
+                                    input: {
+                                        endAdornment: (
+                                            <InputAdornment position="end">
+                                                <IconButton
+                                                    onClick={this.handleSearch}
+                                                    size="small"
+                                                    edge="end"
+                                                >
+                                                    <SearchIcon fontSize="small" />
+                                                </IconButton>
+                                            </InputAdornment>
+                                        ),
+                                    },
+                                }}
+                            />
+                            <Tooltip title={I18n.t('Filter')}>
+                                <IconButton
+                                    onClick={e => this.setState({ filterAnchorEl: e.currentTarget })}
+                                    size="small"
+                                    sx={{ mr: 1 }}
+                                >
+                                    <FilterListIcon />
+                                </IconButton>
+                            </Tooltip>
+                            <Menu
+                                anchorEl={this.state.filterAnchorEl}
+                                open={Boolean(this.state.filterAnchorEl)}
+                                onClose={() => this.setState({ filterAnchorEl: null })}
+                            >
+                                <MenuItem
+                                    onClick={() => this.setState(s => ({ hideOfflineNodes: !s.hideOfflineNodes }))}
+                                >
+                                    <Checkbox
+                                        edge="start"
+                                        checked={this.state.hideOfflineNodes}
+                                        disableRipple
+                                    />
+                                    <ListItemText primary={I18n.t('Hide offline nodes')} />
+                                </MenuItem>
+                                <MenuItem
+                                    onClick={() =>
+                                        this.setState(s => ({ hideWeakSignalEdges: !s.hideWeakSignalEdges }))
+                                    }
+                                >
+                                    <Checkbox
+                                        edge="start"
+                                        checked={this.state.hideWeakSignalEdges}
+                                        disableRipple
+                                    />
+                                    <ListItemText primary={I18n.t('Hide weak links')} />
+                                </MenuItem>
+                                <MenuItem
+                                    onClick={() =>
+                                        this.setState(s => ({ hideMediumSignalEdges: !s.hideMediumSignalEdges }))
+                                    }
+                                >
+                                    <Checkbox
+                                        edge="start"
+                                        checked={this.state.hideMediumSignalEdges}
+                                        disableRipple
+                                    />
+                                    <ListItemText primary={I18n.t('Hide medium links')} />
+                                </MenuItem>
+                                <MenuItem
+                                    onClick={() =>
+                                        this.setState(s => ({ hideStrongSignalEdges: !s.hideStrongSignalEdges }))
+                                    }
+                                >
+                                    <Checkbox
+                                        edge="start"
+                                        checked={this.state.hideStrongSignalEdges}
+                                        disableRipple
+                                    />
+                                    <ListItemText primary={I18n.t('Hide strong links')} />
+                                </MenuItem>
+                            </Menu>
+                        </>
+                    )}
                     <Box sx={{ display: 'flex', gap: 0.5, mr: 1 }}>
                         <Tooltip title={I18n.t('Zoom in')}>
                             <IconButton

--- a/src-admin/src/components/network/NetworkGraphDialog.tsx
+++ b/src-admin/src/components/network/NetworkGraphDialog.tsx
@@ -37,13 +37,15 @@ import {
     Search as SearchIcon,
 } from '@mui/icons-material';
 
-import type { NetworkGraphData, NetworkNodeData, BorderRouterEntry } from './NetworkTypes';
+import type { NetworkGraphData, NetworkNodeData, BorderRouterEntry, ThreadExternalDevice } from './NetworkTypes';
 import {
     SIGNAL_COLORS,
     categorizeNodes,
+    decodeMeshcopStateBitmap,
     formatNodeIdHex,
     formatThreadVersion,
     getThreadRoleName,
+    stripMdnsHostname,
     getWiFiSecurityTypeName,
     getWiFiVersionName,
     parseExtendedAddressToHex,
@@ -236,6 +238,109 @@ class NetworkGraphDialog extends React.Component<NetworkGraphDialogProps, Networ
 
         const nodeType: SelectedNodeType = node.isConnected ? 'online' : 'offline';
         return { node, nodeType, isUnknown: false };
+    }
+
+    /**
+     * Resolve the selected graph node to an external Thread device (border router or
+     * unidentified neighbor) when its id is a `br_`/`unknown_` synthetic id.
+     */
+    getSelectedExternalDevice(): ThreadExternalDevice | null {
+        const { data, networkType } = this.props;
+        const { selectedNodeId } = this.state;
+        if (
+            !selectedNodeId ||
+            !data ||
+            networkType !== 'thread' ||
+            (!selectedNodeId.startsWith('br_') && !selectedNodeId.startsWith('unknown_'))
+        ) {
+            return null;
+        }
+        const threadNodes = data.nodes.filter(n => n.networkType === 'thread');
+        const extAddrMap = buildExtAddrMap(threadNodes);
+        const rloc16Map = buildRloc16Map(threadNodes);
+        const externals = findUnknownDevices(threadNodes, extAddrMap, rloc16Map, this.getBorderRoutersMap());
+        return externals.find(d => d.id === selectedNodeId) ?? null;
+    }
+
+    /** Body details for an external Thread device (border router or unidentified neighbor). */
+    renderExternalDeviceDetails(device: ThreadExternalDevice): React.ReactNode {
+        const { data } = this.props;
+        const observerNames = device.seenBy.map(id => data?.nodes.find(n => n.nodeId === id)?.name ?? id);
+        const rows: { label: string; value: React.ReactNode; mono?: boolean }[] = [];
+
+        if (device.networkName) {
+            rows.push({ label: I18n.t('Network'), value: device.networkName });
+        }
+        if (device.kind === 'br') {
+            if (device.vendorName) {
+                rows.push({ label: I18n.t('Vendor'), value: device.vendorName });
+            }
+            if (device.modelName) {
+                rows.push({ label: I18n.t('Model'), value: device.modelName });
+            }
+            if (device.threadVersion) {
+                rows.push({ label: I18n.t('Thread Version'), value: `Thread ${device.threadVersion}` });
+            }
+            const decoded = decodeMeshcopStateBitmap(device.stateBitmapHex);
+            if (decoded !== undefined) {
+                const roleNames = ['Detached', 'Child', 'Router', 'Leader'];
+                const role = I18n.t(roleNames[decoded.threadRoleValue]);
+                const bbr = decoded.bbr
+                    ? ` · ${I18n.t('Border Agent')} (${I18n.t(decoded.bbrFunction ?? 'secondary')})`
+                    : '';
+                rows.push({ label: I18n.t('Role'), value: `${role}${bbr}` });
+            }
+            if (device.partitionIdHex) {
+                rows.push({ label: I18n.t('Partition'), value: device.partitionIdHex, mono: true });
+            }
+        } else if (device.bestRssi !== null) {
+            rows.push({ label: I18n.t('RSSI'), value: `${device.bestRssi} dBm` });
+        }
+
+        return (
+            <>
+                <Divider />
+                <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.5 }}>
+                    <Typography
+                        variant="body2"
+                        sx={{ wordBreak: 'break-all' }}
+                    >
+                        <strong>{I18n.t('Extended Address')}:</strong>{' '}
+                        <span style={{ fontFamily: 'monospace', fontSize: '0.85em' }}>{device.extAddressHex}</span>
+                    </Typography>
+                    {rows.map(row => (
+                        <Typography
+                            key={row.label}
+                            variant="body2"
+                            sx={{ wordBreak: 'break-all' }}
+                        >
+                            <strong>{row.label}:</strong>{' '}
+                            {row.mono ? (
+                                <span style={{ fontFamily: 'monospace', fontSize: '0.85em' }}>{row.value}</span>
+                            ) : (
+                                row.value
+                            )}
+                        </Typography>
+                    ))}
+                    {device.kind === 'br' && device.addresses.length > 0 && (
+                        <Typography
+                            variant="body2"
+                            sx={{ wordBreak: 'break-all' }}
+                        >
+                            <strong>{I18n.t('Addresses')}:</strong>{' '}
+                            <span style={{ fontFamily: 'monospace', fontSize: '0.8em' }}>
+                                {device.addresses.join(', ')}
+                            </span>
+                        </Typography>
+                    )}
+                    {observerNames.length > 0 && (
+                        <Typography variant="body2">
+                            <strong>{I18n.t('Seen by')}:</strong> {observerNames.join(', ')}
+                        </Typography>
+                    )}
+                </Box>
+            </>
+        );
     }
 
     /**
@@ -512,8 +617,25 @@ class NetworkGraphDialog extends React.Component<NetworkGraphDialogProps, Networ
             );
         }
 
-        const { node, nodeType, isUnknown, unknownExtAddress } = this.getSelectedNodeInfo();
+        const { node, nodeType } = this.getSelectedNodeInfo();
+        const externalDevice = this.getSelectedExternalDevice();
         const onlineNeighborIds = this.getOnlineNeighborIds();
+
+        let externalTitle = '';
+        let externalSubtitle: string | undefined;
+        if (externalDevice) {
+            if (externalDevice.kind === 'br') {
+                const hostname =
+                    externalDevice.hostname !== undefined ? stripMdnsHostname(externalDevice.hostname) : undefined;
+                externalTitle = hostname ?? externalDevice.networkName ?? I18n.t('Border Router');
+                externalSubtitle =
+                    externalDevice.networkName && externalDevice.networkName !== externalTitle
+                        ? externalDevice.networkName
+                        : undefined;
+            } else {
+                externalTitle = externalDevice.isRouter ? I18n.t('External Router') : I18n.t('External Device');
+            }
+        }
 
         return (
             <Paper
@@ -522,20 +644,22 @@ class NetworkGraphDialog extends React.Component<NetworkGraphDialogProps, Networ
             >
                 <Box sx={{ display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between' }}>
                     <Box sx={{ flex: 1, minWidth: 0 }}>
-                        {isUnknown ? (
+                        {externalDevice ? (
                             <>
                                 <Typography
                                     variant="subtitle2"
-                                    sx={{ fontWeight: 'bold' }}
+                                    sx={{ fontWeight: 'bold', wordBreak: 'break-word' }}
                                 >
-                                    {I18n.t('Unknown Device')}
+                                    {externalTitle}
                                 </Typography>
-                                <Typography
-                                    variant="caption"
-                                    sx={{ fontFamily: 'monospace', color: 'text.secondary', wordBreak: 'break-all' }}
-                                >
-                                    {unknownExtAddress}
-                                </Typography>
+                                {externalSubtitle && (
+                                    <Typography
+                                        variant="caption"
+                                        sx={{ color: 'text.secondary', display: 'block' }}
+                                    >
+                                        {externalSubtitle}
+                                    </Typography>
+                                )}
                             </>
                         ) : node ? (
                             <>
@@ -666,6 +790,8 @@ class NetworkGraphDialog extends React.Component<NetworkGraphDialogProps, Networ
                     </>
                 )}
 
+                {externalDevice && this.renderExternalDeviceDetails(externalDevice)}
+
                 {/* Connections list for Thread nodes */}
                 {node && node.networkType === 'thread' && this.renderConnectionsList(node)}
 
@@ -674,7 +800,7 @@ class NetworkGraphDialog extends React.Component<NetworkGraphDialogProps, Networ
                     <UpdateConnectionsDialog
                         open={this.state.updateDialogOpen}
                         selectedNodeType={nodeType}
-                        selectedNodeName={isUnknown ? I18n.t('Unknown Device') : (node?.name ?? '')}
+                        selectedNodeName={externalDevice ? externalTitle : (node?.name ?? '')}
                         selectedNodeId={selectedNodeId}
                         onlineNeighborIds={onlineNeighborIds}
                         onClose={this.handleCloseUpdateDialog}

--- a/src-admin/src/components/network/NetworkIcons.ts
+++ b/src-admin/src/components/network/NetworkIcons.ts
@@ -1,0 +1,380 @@
+/**
+ * NetworkIcons - SVG data-URL generators for network graph nodes
+ *
+ * vis-network renders `shape: 'image'` nodes from a data URL. We compose icons from `@mdi/js`
+ * glyph paths (CSP-safe, no external assets) so device-type, Thread role, Border Router and
+ * unknown-device nodes render distinctly. Device-type → glyph mapping mirrors matterjs-server.
+ */
+
+import {
+    mdiAccessPoint,
+    mdiAirConditioner,
+    mdiAirFilter,
+    mdiAirPurifier,
+    mdiBell,
+    mdiBlindsHorizontal,
+    mdiBrightnessPercent,
+    mdiCamera,
+    mdiCast,
+    mdiCctv,
+    mdiChip,
+    mdiCircleMedium,
+    mdiCrown,
+    mdiDishwasher,
+    mdiDoorbell,
+    mdiDoorbellVideo,
+    mdiDoorOpen,
+    mdiEvStation,
+    mdiFan,
+    mdiFridge,
+    mdiGauge,
+    mdiHeatPump,
+    mdiHelp,
+    mdiHome,
+    mdiLeaf,
+    mdiLightbulb,
+    mdiLock,
+    mdiMeterElectric,
+    mdiMicrowave,
+    mdiMotionSensor,
+    mdiPowerPlug,
+    mdiPump,
+    mdiRemote,
+    mdiRobotVacuum,
+    mdiRouter,
+    mdiRouterWireless,
+    mdiSleep,
+    mdiSmokeDetector,
+    mdiSnowflakeAlert,
+    mdiSolarPower,
+    mdiSpeaker,
+    mdiSprinkler,
+    mdiStar,
+    mdiStove,
+    mdiSwapHorizontal,
+    mdiTelevision,
+    mdiThermometer,
+    mdiToggleSwitch,
+    mdiTumbleDryer,
+    mdiWashingMachine,
+    mdiWater,
+    mdiWaterBoiler,
+    mdiWaterPercent,
+    mdiWeatherRainy,
+    mdiWifi,
+} from '@mdi/js';
+
+// Node base colors
+const COLOR_SELECTED = '#1976D2';
+const COLOR_OFFLINE = '#D32F2F';
+const COLOR_DEFAULT = '#607D8B';
+const COLOR_BR_PRIMARY = '#03A9F4';
+const COLOR_UNKNOWN = '#FF9800';
+
+// Thread role colors (base disc + matching badge)
+const COLOR_ROLE_LEADER = '#F9A825';
+const COLOR_ROLE_ROUTER = '#1E88E5';
+const COLOR_ROLE_REED = '#039BE5';
+const COLOR_ROLE_ENDDEVICE = '#4CAF50';
+const COLOR_PRIMARY_BBR = '#00897B';
+
+/** Matter device-type ids (Matter Device Library 1.5). */
+const DeviceTypes = {
+    ROOT_NODE: 0x0016,
+    ELECTRICAL_SENSOR: 0x0510,
+    DEVICE_ENERGY_MANAGEMENT: 0x050d,
+
+    ON_OFF_LIGHT: 0x0100,
+    DIMMABLE_LIGHT: 0x0101,
+    COLOR_TEMPERATURE_LIGHT: 0x010c,
+    EXTENDED_COLOR_LIGHT: 0x010d,
+
+    ON_OFF_PLUG: 0x010a,
+    DIMMABLE_PLUG: 0x010b,
+    MOUNTED_ON_OFF_CONTROL: 0x010f,
+    MOUNTED_DIMMABLE_LOAD_CONTROL: 0x0110,
+    PUMP: 0x0303,
+    WATER_VALVE: 0x0042,
+    IRRIGATION_SYSTEM: 0x0040,
+
+    ON_OFF_SWITCH: 0x0103,
+    DIMMER_SWITCH: 0x0104,
+    COLOR_DIMMER_SWITCH: 0x0105,
+    CONTROL_BRIDGE: 0x0840,
+    PUMP_CONTROLLER: 0x0304,
+    GENERIC_SWITCH: 0x000f,
+
+    CONTACT_SENSOR: 0x0015,
+    LIGHT_SENSOR: 0x0106,
+    OCCUPANCY_SENSOR: 0x0107,
+    TEMPERATURE_SENSOR: 0x0302,
+    PRESSURE_SENSOR: 0x0305,
+    FLOW_SENSOR: 0x0306,
+    HUMIDITY_SENSOR: 0x0307,
+    ON_OFF_SENSOR: 0x0850,
+    SMOKE_CO_ALARM: 0x0076,
+    AIR_QUALITY_SENSOR: 0x002c,
+    WATER_FREEZE_DETECTOR: 0x0041,
+    WATER_LEAK_DETECTOR: 0x0043,
+    RAIN_SENSOR: 0x0044,
+    SOIL_SENSOR: 0x0045,
+
+    DOOR_LOCK: 0x000a,
+    DOOR_LOCK_CONTROLLER: 0x000b,
+    WINDOW_COVERING: 0x0202,
+    WINDOW_COVERING_CONTROLLER: 0x0203,
+    CLOSURE: 0x0230,
+    CLOSURE_PANEL: 0x0231,
+    CLOSURE_CONTROLLER: 0x023e,
+
+    THERMOSTAT: 0x0301,
+    FAN: 0x002b,
+    AIR_PURIFIER: 0x002d,
+    THERMOSTAT_CONTROLLER: 0x030a,
+    HEAT_PUMP: 0x0309,
+    ROOM_AIR_CONDITIONER: 0x0072,
+
+    SPEAKER: 0x0022,
+    CASTING_VIDEO_PLAYER: 0x0023,
+    CONTENT_APP: 0x0024,
+    BASIC_VIDEO_PLAYER: 0x0028,
+    CASTING_VIDEO_CLIENT: 0x0029,
+    VIDEO_REMOTE_CONTROL: 0x002a,
+
+    AGGREGATOR: 0x000e,
+
+    REFRIGERATOR: 0x0070,
+    TEMPERATURE_CONTROLLED_CABINET: 0x0071,
+    LAUNDRY_WASHER: 0x0073,
+    ROBOTIC_VACUUM_CLEANER: 0x0074,
+    DISHWASHER: 0x0075,
+    COOK_SURFACE: 0x0077,
+    COOKTOP: 0x0078,
+    MICROWAVE_OVEN: 0x0079,
+    EXTRACTOR_HOOD: 0x007a,
+    OVEN: 0x007b,
+    LAUNDRY_DRYER: 0x007c,
+
+    EVSE: 0x050c,
+    WATER_HEATER: 0x050f,
+    SOLAR_POWER: 0x0017,
+    BATTERY_STORAGE: 0x0018,
+
+    NETWORK_INFRASTRUCTURE_MANAGER: 0x0090,
+    THREAD_BORDER_ROUTER: 0x0091,
+
+    CAMERA: 0x0142,
+    SNAPSHOT_CAMERA: 0x0145,
+    VIDEO_DOORBELL: 0x0143,
+    AUDIO_DOORBELL: 0x0141,
+    FLOODLIGHT_CAMERA: 0x0144,
+    DOORBELL: 0x0148,
+    CHIME: 0x0146,
+    CAMERA_CONTROLLER: 0x0147,
+    INTERCOM: 0x0140,
+} as const;
+
+/** Maps device-type ids to MDI glyph paths (mirrors matterjs-server deviceTypeToIcon). */
+const deviceTypeToIcon: Record<number, string> = {
+    [DeviceTypes.ROOT_NODE]: mdiHome,
+    [DeviceTypes.ELECTRICAL_SENSOR]: mdiMeterElectric,
+    [DeviceTypes.DEVICE_ENERGY_MANAGEMENT]: mdiMeterElectric,
+
+    [DeviceTypes.ON_OFF_LIGHT]: mdiLightbulb,
+    [DeviceTypes.DIMMABLE_LIGHT]: mdiLightbulb,
+    [DeviceTypes.COLOR_TEMPERATURE_LIGHT]: mdiLightbulb,
+    [DeviceTypes.EXTENDED_COLOR_LIGHT]: mdiLightbulb,
+
+    [DeviceTypes.ON_OFF_PLUG]: mdiPowerPlug,
+    [DeviceTypes.DIMMABLE_PLUG]: mdiPowerPlug,
+    [DeviceTypes.MOUNTED_ON_OFF_CONTROL]: mdiPowerPlug,
+    [DeviceTypes.MOUNTED_DIMMABLE_LOAD_CONTROL]: mdiPowerPlug,
+    [DeviceTypes.PUMP]: mdiPump,
+    [DeviceTypes.WATER_VALVE]: mdiWater,
+    [DeviceTypes.IRRIGATION_SYSTEM]: mdiSprinkler,
+
+    [DeviceTypes.ON_OFF_SWITCH]: mdiToggleSwitch,
+    [DeviceTypes.DIMMER_SWITCH]: mdiToggleSwitch,
+    [DeviceTypes.COLOR_DIMMER_SWITCH]: mdiToggleSwitch,
+    [DeviceTypes.CONTROL_BRIDGE]: mdiRouter,
+    [DeviceTypes.PUMP_CONTROLLER]: mdiPump,
+    [DeviceTypes.GENERIC_SWITCH]: mdiToggleSwitch,
+
+    [DeviceTypes.CONTACT_SENSOR]: mdiDoorOpen,
+    [DeviceTypes.LIGHT_SENSOR]: mdiBrightnessPercent,
+    [DeviceTypes.OCCUPANCY_SENSOR]: mdiMotionSensor,
+    [DeviceTypes.TEMPERATURE_SENSOR]: mdiThermometer,
+    [DeviceTypes.PRESSURE_SENSOR]: mdiGauge,
+    [DeviceTypes.FLOW_SENSOR]: mdiWater,
+    [DeviceTypes.HUMIDITY_SENSOR]: mdiWaterPercent,
+    [DeviceTypes.ON_OFF_SENSOR]: mdiMotionSensor,
+    [DeviceTypes.SMOKE_CO_ALARM]: mdiSmokeDetector,
+    [DeviceTypes.AIR_QUALITY_SENSOR]: mdiAirFilter,
+    [DeviceTypes.WATER_FREEZE_DETECTOR]: mdiSnowflakeAlert,
+    [DeviceTypes.WATER_LEAK_DETECTOR]: mdiWater,
+    [DeviceTypes.RAIN_SENSOR]: mdiWeatherRainy,
+    [DeviceTypes.SOIL_SENSOR]: mdiLeaf,
+
+    [DeviceTypes.DOOR_LOCK]: mdiLock,
+    [DeviceTypes.DOOR_LOCK_CONTROLLER]: mdiLock,
+    [DeviceTypes.WINDOW_COVERING]: mdiBlindsHorizontal,
+    [DeviceTypes.WINDOW_COVERING_CONTROLLER]: mdiBlindsHorizontal,
+    [DeviceTypes.CLOSURE]: mdiDoorOpen,
+    [DeviceTypes.CLOSURE_PANEL]: mdiDoorOpen,
+    [DeviceTypes.CLOSURE_CONTROLLER]: mdiDoorOpen,
+
+    [DeviceTypes.THERMOSTAT]: mdiThermometer,
+    [DeviceTypes.FAN]: mdiFan,
+    [DeviceTypes.AIR_PURIFIER]: mdiAirPurifier,
+    [DeviceTypes.THERMOSTAT_CONTROLLER]: mdiThermometer,
+    [DeviceTypes.HEAT_PUMP]: mdiHeatPump,
+    [DeviceTypes.ROOM_AIR_CONDITIONER]: mdiAirConditioner,
+
+    [DeviceTypes.SPEAKER]: mdiSpeaker,
+    [DeviceTypes.CASTING_VIDEO_PLAYER]: mdiTelevision,
+    [DeviceTypes.CONTENT_APP]: mdiTelevision,
+    [DeviceTypes.BASIC_VIDEO_PLAYER]: mdiTelevision,
+    [DeviceTypes.CASTING_VIDEO_CLIENT]: mdiCast,
+    [DeviceTypes.VIDEO_REMOTE_CONTROL]: mdiRemote,
+
+    [DeviceTypes.AGGREGATOR]: mdiRouter,
+
+    [DeviceTypes.REFRIGERATOR]: mdiFridge,
+    [DeviceTypes.TEMPERATURE_CONTROLLED_CABINET]: mdiFridge,
+    [DeviceTypes.LAUNDRY_WASHER]: mdiWashingMachine,
+    [DeviceTypes.ROBOTIC_VACUUM_CLEANER]: mdiRobotVacuum,
+    [DeviceTypes.DISHWASHER]: mdiDishwasher,
+    [DeviceTypes.COOK_SURFACE]: mdiStove,
+    [DeviceTypes.COOKTOP]: mdiStove,
+    [DeviceTypes.MICROWAVE_OVEN]: mdiMicrowave,
+    [DeviceTypes.EXTRACTOR_HOOD]: mdiFan,
+    [DeviceTypes.OVEN]: mdiStove,
+    [DeviceTypes.LAUNDRY_DRYER]: mdiTumbleDryer,
+
+    [DeviceTypes.EVSE]: mdiEvStation,
+    [DeviceTypes.WATER_HEATER]: mdiWaterBoiler,
+    [DeviceTypes.SOLAR_POWER]: mdiSolarPower,
+    [DeviceTypes.BATTERY_STORAGE]: mdiMeterElectric,
+
+    [DeviceTypes.NETWORK_INFRASTRUCTURE_MANAGER]: mdiRouter,
+    [DeviceTypes.THREAD_BORDER_ROUTER]: mdiAccessPoint,
+
+    [DeviceTypes.CAMERA]: mdiCamera,
+    [DeviceTypes.SNAPSHOT_CAMERA]: mdiCamera,
+    [DeviceTypes.VIDEO_DOORBELL]: mdiDoorbellVideo,
+    [DeviceTypes.AUDIO_DOORBELL]: mdiDoorbell,
+    [DeviceTypes.FLOODLIGHT_CAMERA]: mdiCctv,
+    [DeviceTypes.DOORBELL]: mdiDoorbell,
+    [DeviceTypes.CHIME]: mdiBell,
+    [DeviceTypes.CAMERA_CONTROLLER]: mdiCamera,
+    [DeviceTypes.INTERCOM]: mdiDoorbell,
+};
+
+/** MDI glyph path for a Matter device-type id; generic chip glyph for unknown/undefined. */
+export function getDeviceTypeIconPath(deviceType: number | undefined): string {
+    if (deviceType === undefined) {
+        return mdiChip;
+    }
+    return deviceTypeToIcon[deviceType] ?? mdiChip;
+}
+
+interface RoleBadge {
+    iconPath: string;
+    color: string;
+}
+
+/**
+ * Corner badge marking a node's Thread RoutingRole (attr 0/53/1), overlaid on the device icon.
+ * Leader is the high-signal exception (crown); routers and end devices use lower-key glyphs.
+ * Unassigned/Unspecified/unknown roles get no badge.
+ */
+const THREAD_ROLE_BADGES: Record<number, RoleBadge> = {
+    2: { iconPath: mdiSleep, color: COLOR_ROLE_ENDDEVICE }, // Sleepy End Device
+    3: { iconPath: mdiCircleMedium, color: COLOR_ROLE_ENDDEVICE }, // End Device
+    4: { iconPath: mdiCircleMedium, color: COLOR_ROLE_REED }, // REED
+    5: { iconPath: mdiSwapHorizontal, color: COLOR_ROLE_ROUTER }, // Router
+    6: { iconPath: mdiCrown, color: COLOR_ROLE_LEADER }, // Leader
+};
+
+function roleColor(role: number | null | undefined): string {
+    switch (role) {
+        case 6:
+            return COLOR_ROLE_LEADER;
+        case 5:
+            return COLOR_ROLE_ROUTER;
+        case 4:
+            return COLOR_ROLE_REED;
+        case 3:
+        case 2:
+            return COLOR_ROLE_ENDDEVICE;
+        default:
+            return COLOR_DEFAULT;
+    }
+}
+
+/**
+ * Builds an SVG data URL: a white disc bordered in `color` with `iconPath` centered,
+ * and an optional top-right corner badge (white glyph on a colored disc).
+ */
+function createIconDataUrl(
+    iconPath: string,
+    color: string,
+    size = 48,
+    badge?: { iconPath: string; color: string },
+): string {
+    const badgeMarkup =
+        badge !== undefined
+            ? `<circle cx="18" cy="6" r="4" fill="${badge.color}"/><path d="${badge.iconPath}" fill="white" transform="translate(14.64,2.64) scale(0.28)"/>`
+            : '';
+    const svg =
+        `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="${size}" height="${size}">` +
+        `<circle cx="12" cy="12" r="11" fill="white" stroke="${color}" stroke-width="1"/>` +
+        `<path d="${iconPath}" fill="${color}" transform="scale(0.6) translate(8,8)"/>` +
+        `${badgeMarkup}</svg>`;
+    return `data:image/svg+xml;charset=utf-8,${encodeURIComponent(svg)}`;
+}
+
+/**
+ * Icon for a commissioned device: the device-type glyph colored by Thread role (or the default
+ * colour for non-Thread nodes), with the Thread role badge overlay (crown/swap/circle/sleep).
+ */
+export function createNodeIconDataUrl(
+    deviceType: number | undefined,
+    role: number | null | undefined,
+    isOffline = false,
+    isSelected = false,
+): string {
+    let color: string;
+    if (isSelected) {
+        color = COLOR_SELECTED;
+    } else if (isOffline) {
+        color = COLOR_OFFLINE;
+    } else {
+        color = roleColor(role);
+    }
+    const badge = role != null ? THREAD_ROLE_BADGES[role] : undefined;
+    return createIconDataUrl(getDeviceTypeIconPath(deviceType), color, 48, badge);
+}
+
+/**
+ * Icon for an mDNS-discovered Thread Border Router. Mesh role (crown for leader, router-wireless
+ * otherwise) is the central glyph; a corner star marks the primary Backbone Border Router.
+ */
+export function createBorderRouterIconDataUrl(isSelected = false, isLeader = false, isPrimaryBbr = false): string {
+    const glyph = isLeader ? mdiCrown : mdiRouterWireless;
+    const color = isSelected ? COLOR_SELECTED : isLeader ? COLOR_ROLE_LEADER : COLOR_BR_PRIMARY;
+    const badge = isPrimaryBbr ? { iconPath: mdiStar, color: COLOR_PRIMARY_BBR } : undefined;
+    return createIconDataUrl(glyph, color, 48, badge);
+}
+
+/** Icon for an unidentified external Thread neighbor (question mark, or access-point if router-like). */
+export function createUnknownDeviceIconDataUrl(isRouter = false, isSelected = false): string {
+    const iconPath = isRouter ? mdiAccessPoint : mdiHelp;
+    const color = isSelected ? COLOR_SELECTED : COLOR_UNKNOWN;
+    return createIconDataUrl(iconPath, color, 48);
+}
+
+/** Icon for a WiFi access point. */
+export function createWiFiApIconDataUrl(isSelected = false): string {
+    return createIconDataUrl(mdiWifi, isSelected ? COLOR_SELECTED : COLOR_UNKNOWN, 48);
+}

--- a/src-admin/src/components/network/NetworkTypes.ts
+++ b/src-admin/src/components/network/NetworkTypes.ts
@@ -12,7 +12,16 @@ export type {
     ThreadDiagnosticsData,
     ThreadNeighborEntry,
     ThreadRouteEntry,
+    BorderRouterEntry,
 } from '../../types';
+
+import type { BorderRouterEntry, NetworkType } from '../../types';
+
+/**
+ * Classification of a Thread mesh link based on LQI.
+ * "none" means LQI=0 — neighbor entry exists but no recent valid frames (dead/stale link).
+ */
+export type SignalLevel = 'strong' | 'medium' | 'weak' | 'none';
 
 /**
  * Thread Routing Role enum for display purposes
@@ -44,6 +53,8 @@ export interface NetworkGraphNode {
     offline?: boolean;
     isUnknown?: boolean;
     isAccessPoint?: boolean;
+    /** Whether the node should be hidden (filter options) */
+    hidden?: boolean;
 }
 
 export interface NetworkGraphEdge {
@@ -54,6 +65,8 @@ export interface NetworkGraphEdge {
     width: number;
     title?: string;
     dashes?: boolean;
+    /** Whether the edge should be hidden (filter options) */
+    hidden?: boolean;
 }
 
 export interface WiFiAccessPoint {
@@ -63,13 +76,40 @@ export interface WiFiAccessPoint {
 }
 
 export interface UnknownThreadDevice {
+    kind: 'unknown';
+    /** Unique graph ID, formatted "unknown_<XAHEX>". */
     id: string;
+    /** Extended address as base64 (as received in the neighbor table). */
     extAddress: string;
+    /** Extended address as 16-char uppercase hex — the join key. */
     extAddressHex: string;
     isRouter: boolean;
     bestRssi: number | null;
     seenBy: string[];
+    /** Extended PAN ID (16-char uppercase hex) inherited from the observing commissioned node. */
+    extendedPanIdHex?: string;
+    /** Friendly Thread network name resolved by joining extendedPanIdHex against the BR registry. */
+    networkName?: string;
 }
+
+/**
+ * Thread Border Router enriched via mDNS. Same neighbor-table aggregate fields as
+ * UnknownThreadDevice plus all BorderRouterEntry fields (network name, vendor, addresses, ...).
+ */
+export interface KnownBorderRouter extends BorderRouterEntry {
+    kind: 'br';
+    /** Graph ID, formatted "br_<XAHEX>". */
+    id: string;
+    isRouter: boolean;
+    bestRssi: number | null;
+    seenBy: string[];
+}
+
+/**
+ * External Thread device discriminated union — either a recognized Border Router
+ * or an unidentified neighbor.
+ */
+export type ThreadExternalDevice = KnownBorderRouter | UnknownThreadDevice;
 
 // Signal strength colors
 export interface SignalColor {

--- a/src-admin/src/components/network/NetworkUtils.ts
+++ b/src-admin/src/components/network/NetworkUtils.ts
@@ -8,18 +8,22 @@ import type {
     ThreadNeighborEntry,
     ThreadRouteEntry,
     SignalColor,
-    UnknownThreadDevice,
+    SignalLevel,
+    ThreadExternalDevice,
+    BorderRouterEntry,
     WiFiAccessPoint,
     ThreadRoutingRole,
 } from './NetworkTypes';
 
-// Signal strength thresholds (dBm)
+// WiFi RSSI thresholds (dBm). Used only for the WiFi graph; Thread edges are LQI-driven.
 const SIGNAL_STRONG_THRESHOLD = -70;
 const SIGNAL_MEDIUM_THRESHOLD = -85;
 
-// LQI thresholds (0-255)
-const LQI_STRONG_THRESHOLD = 200;
-const LQI_MEDIUM_THRESHOLD = 100;
+// Thread LQI thresholds. Spec types LQI as uint8 (0-255), but OpenThread — the dominant
+// Thread stack — only ever reports 0-3, so we classify on that scale: 3=strong, 2=medium,
+// 1=weak, 0=no link (stale/dead neighbor entry).
+const LQI_STRONG_THRESHOLD = 2;
+const LQI_MEDIUM_THRESHOLD = 1;
 
 // Signal colors
 export const SIGNAL_COLORS = {
@@ -89,27 +93,105 @@ export function getSignalColorFromRssi(rssi: number | null): SignalColor {
 }
 
 /**
- * Get signal color based on LQI value (0-255)
+ * Map an LQI value to a signal level. OpenThread reports 0-3 in practice (see thresholds);
+ * 0 = "none" (no recent valid frames — stale/dead link).
  */
-export function getSignalColorFromLqi(lqi: number): SignalColor {
+export function getSignalLevelFromLqi(lqi: number): SignalLevel {
+    if (lqi <= 0) {
+        return 'none';
+    }
     if (lqi > LQI_STRONG_THRESHOLD) {
-        return SIGNAL_COLORS.strong;
+        return 'strong';
     }
     if (lqi > LQI_MEDIUM_THRESHOLD) {
-        return SIGNAL_COLORS.medium;
+        return 'medium';
     }
-    return SIGNAL_COLORS.weak;
+    return 'weak';
 }
 
 /**
- * Get signal color from neighbor entry (prefers RSSI, falls back to LQI)
+ * Get signal color based on LQI value (0-3 on OpenThread; 0 = no link → grey).
+ */
+export function getSignalColorFromLqi(lqi: number): SignalColor {
+    switch (getSignalLevelFromLqi(lqi)) {
+        case 'strong':
+            return SIGNAL_COLORS.strong;
+        case 'medium':
+            return SIGNAL_COLORS.medium;
+        case 'weak':
+            return SIGNAL_COLORS.weak;
+        default:
+            return SIGNAL_COLORS.unknown;
+    }
+}
+
+/**
+ * Get signal color for a Thread neighbor. Thread edges are LQI-driven (OpenThread 0-3);
+ * RSSI is retained for tooltips/details only, not for edge coloring.
  */
 export function getSignalColorFromNeighbor(neighbor: ThreadNeighborEntry): SignalColor {
-    const rssi = neighbor.averageRssi ?? neighbor.lastRssi;
-    if (rssi !== null) {
-        return getSignalColorFromRssi(rssi);
-    }
     return getSignalColorFromLqi(neighbor.lqi);
+}
+
+/** Strips trailing dot and `.local` suffix from an mDNS hostname for display. */
+export function stripMdnsHostname(hostname: string): string {
+    return hostname.replace(/\.$/, '').replace(/\.local$/i, '');
+}
+
+/**
+ * Decoded form of the MeshCoP `_meshcop` TXT `sb` (state bitmap) field. Layout per OpenThread's
+ * border-agent service publication (the de-facto reference for Thread Border Routers):
+ *   bit  7     BBR Active
+ *   bit  8     BBR Is Primary (only meaningful when BBR Active)
+ *   bits 9-10  Thread Role (0=Detached, 1=Child, 2=Router, 3=Leader)
+ */
+export interface DecodedStateBitmap {
+    bbr: boolean;
+    /** "primary" / "secondary" — only meaningful when bbr is true. */
+    bbrFunction?: 'primary' | 'secondary';
+    threadRoleValue: number;
+}
+
+/** Decodes a MeshCoP state bitmap hex string (e.g. "000005B1"); undefined if not valid hex. */
+export function decodeMeshcopStateBitmap(hex: string | undefined): DecodedStateBitmap | undefined {
+    if (hex === undefined || !/^[0-9a-fA-F]{1,8}$/.test(hex)) {
+        return undefined;
+    }
+    const value = parseInt(hex, 16);
+    if (!Number.isFinite(value)) {
+        return undefined;
+    }
+    const bbr = ((value >> 7) & 0x1) === 1;
+    const bbrIsPrimary = ((value >> 8) & 0x1) === 1;
+    return {
+        bbr,
+        bbrFunction: bbr ? (bbrIsPrimary ? 'primary' : 'secondary') : undefined,
+        threadRoleValue: (value >> 9) & 0x3,
+    };
+}
+
+/**
+ * Snapshot of mDNS-discovered Thread Border Routers, keyed by uppercase 16-char xa hex so callers
+ * can join against neighbor-table extended addresses normalized to the same casing.
+ */
+export class BorderRouterStore {
+    #entries: ReadonlyMap<string, BorderRouterEntry> = new Map();
+
+    get entries(): ReadonlyMap<string, BorderRouterEntry> {
+        return this.#entries;
+    }
+
+    setFromList(list: BorderRouterEntry[]): void {
+        const next = new Map<string, BorderRouterEntry>();
+        for (const entry of list) {
+            next.set(entry.extAddressHex.toUpperCase(), entry);
+        }
+        this.#entries = next;
+    }
+
+    reset(): void {
+        this.#entries = new Map();
+    }
 }
 
 /**
@@ -199,17 +281,38 @@ export function buildRloc16Map(nodes: NetworkNodeData[]): Map<number, string> {
  * Uses RLOC16 fallback to reduce false "unknown" classifications when extended
  * address matching fails (format edge cases, stale data, missing NetworkInterfaces).
  */
+interface ExternalAggregate {
+    extAddress: string;
+    extAddressHex: string;
+    seenBy: string[];
+    isRouter: boolean;
+    bestRssi: number | null;
+    /** xp of the first observing node; all neighbors of a Thread node share its network. */
+    extendedPanIdHex?: string;
+}
+
+/**
+ * Find external Thread devices — addresses seen in neighbor tables that don't match any
+ * commissioned device. Classifies each against the optional Border Router registry: matched
+ * ones become kind:"br" with full mDNS enrichment, the rest stay kind:"unknown". Uses RLOC16
+ * as fallback when extended address matching fails.
+ */
 export function findUnknownDevices(
     nodes: NetworkNodeData[],
     extAddrMap: Map<string, string>,
     rloc16Map: Map<number, string>,
-): UnknownThreadDevice[] {
-    const unknownMap = new Map<string, UnknownThreadDevice>();
+    borderRouters?: ReadonlyMap<string, BorderRouterEntry>,
+): ThreadExternalDevice[] {
+    const aggregates = new Map<string, ExternalAggregate>();
 
     for (const node of nodes) {
         if (node.networkType !== 'thread' || !node.thread?.neighborTable) {
             continue;
         }
+
+        const observerXpHex = node.thread.extendedPanId
+            ? parseExtendedAddressToHex(node.thread.extendedPanId)
+            : undefined;
 
         for (const neighbor of node.thread.neighborTable) {
             const extAddrHex = parseExtendedAddressToHex(neighbor.extAddress);
@@ -219,45 +322,79 @@ export function findUnknownDevices(
                 continue;
             }
 
-            // RLOC16 fallback: check by short address before classifying as unknown
+            // RLOC16 fallback: check by short address before classifying as external
             if (neighbor.rloc16 !== 0 && rloc16Map.has(neighbor.rloc16)) {
                 continue;
             }
 
-            const id = `unknown_${extAddrHex}`;
-
-            if (!unknownMap.has(id)) {
-                unknownMap.set(id, {
-                    id,
+            let agg = aggregates.get(extAddrHex);
+            if (agg === undefined) {
+                agg = {
                     extAddress: neighbor.extAddress,
                     extAddressHex: extAddrHex,
                     seenBy: [],
                     isRouter: false,
                     bestRssi: null,
-                });
+                    extendedPanIdHex: observerXpHex,
+                };
+                aggregates.set(extAddrHex, agg);
+            } else if (agg.extendedPanIdHex === undefined && observerXpHex !== undefined) {
+                agg.extendedPanIdHex = observerXpHex;
             }
 
-            const unknown = unknownMap.get(id)!;
-
-            // Add this node to seenBy if not already there
-            if (!unknown.seenBy.includes(node.nodeId)) {
-                unknown.seenBy.push(node.nodeId);
+            if (!agg.seenBy.includes(node.nodeId)) {
+                agg.seenBy.push(node.nodeId);
             }
-
-            // Update router status (rxOnWhenIdle indicates router-like behavior)
             if (neighbor.rxOnWhenIdle) {
-                unknown.isRouter = true;
+                agg.isRouter = true;
             }
-
-            // Track best signal
             const rssi = neighbor.averageRssi ?? neighbor.lastRssi;
-            if (rssi !== null && (unknown.bestRssi === null || rssi > unknown.bestRssi)) {
-                unknown.bestRssi = rssi;
+            if (rssi !== null && (agg.bestRssi === null || rssi > agg.bestRssi)) {
+                agg.bestRssi = rssi;
             }
         }
     }
 
-    return Array.from(unknownMap.values());
+    // Pre-compute xp → networkName from the BR registry so unknowns can be labeled by network.
+    const networkNameByXp = new Map<string, string>();
+    if (borderRouters !== undefined) {
+        for (const br of borderRouters.values()) {
+            if (br.extendedPanIdHex !== undefined && br.networkName !== undefined) {
+                networkNameByXp.set(br.extendedPanIdHex, br.networkName);
+            }
+        }
+    }
+
+    const out = new Array<ThreadExternalDevice>();
+    for (const agg of aggregates.values()) {
+        const br = borderRouters?.get(agg.extAddressHex);
+        if (br !== undefined) {
+            out.push({
+                kind: 'br',
+                ...br,
+                id: `br_${agg.extAddressHex}`,
+                extAddressHex: agg.extAddressHex,
+                seenBy: agg.seenBy,
+                isRouter: agg.isRouter,
+                bestRssi: agg.bestRssi,
+            });
+        } else {
+            const networkName =
+                agg.extendedPanIdHex !== undefined ? networkNameByXp.get(agg.extendedPanIdHex) : undefined;
+            out.push({
+                kind: 'unknown',
+                id: `unknown_${agg.extAddressHex}`,
+                extAddress: agg.extAddress,
+                extAddressHex: agg.extAddressHex,
+                seenBy: agg.seenBy,
+                isRouter: agg.isRouter,
+                bestRssi: agg.bestRssi,
+                extendedPanIdHex: agg.extendedPanIdHex,
+                networkName,
+            });
+        }
+    }
+    return out;
 }
 
 /**
@@ -313,6 +450,19 @@ export function getThreadRoleName(role: ThreadRoutingRole | number | null): stri
         default:
             return 'Unknown';
     }
+}
+
+/**
+ * Human-readable Thread version from the NetworkCommissioning ThreadVersion TLV.
+ * Unmapped values render with the raw TLV so newer-than-table devices stay visible.
+ */
+export function formatThreadVersion(tlv: number | null): string | null {
+    if (tlv === null) {
+        return null;
+    }
+    const names: Record<number, string> = { 1: '1.0', 2: '1.1', 3: '1.2', 4: '1.3', 5: '1.4' };
+    const name = names[tlv];
+    return name !== undefined ? `Thread ${name}` : `Thread unknown (${tlv})`;
 }
 
 /**
@@ -466,7 +616,7 @@ export function getRouteBidirectionalLqi(route: ThreadRouteEntry): number | unde
 export function buildThreadConnections(
     nodes: NetworkNodeData[],
     extAddrMap: Map<string, string>,
-    unknownDevices: UnknownThreadDevice[],
+    unknownDevices: ThreadExternalDevice[],
     rloc16Map: Map<number, string>,
 ): ThreadConnection[] {
     const connections: ThreadConnection[] = [];

--- a/src-admin/src/components/network/ThreadGraph.tsx
+++ b/src-admin/src/components/network/ThreadGraph.tsx
@@ -1,101 +1,205 @@
 /**
  * ThreadGraph - Thread mesh network visualization
- * Shows Thread devices and their mesh connections with signal quality
+ * Shows Thread devices, Border Routers and their mesh connections with signal quality
  */
 
 import BaseNetworkGraph, { type BaseNetworkGraphProps, type BaseNetworkGraphState } from './BaseNetworkGraph';
-import type { NetworkGraphNode, NetworkGraphEdge, ThreadRoutingRole } from './NetworkTypes';
+import type { NetworkGraphNode, NetworkGraphEdge, ThreadRoutingRole, BorderRouterEntry } from './NetworkTypes';
 import {
     buildExtAddrMap,
     buildRloc16Map,
     findUnknownDevices,
     buildThreadConnections,
     getThreadRoleName,
+    getSignalLevelFromLqi,
+    decodeMeshcopStateBitmap,
+    stripMdnsHostname,
     parseExtendedAddressToHex,
 } from './NetworkUtils';
+import { createNodeIconDataUrl, createBorderRouterIconDataUrl, createUnknownDeviceIconDataUrl } from './NetworkIcons';
 
-class ThreadGraph extends BaseNetworkGraph<BaseNetworkGraphProps, BaseNetworkGraphState> {
+export interface ThreadGraphProps extends BaseNetworkGraphProps {
+    /** mDNS-discovered Thread Border Routers, keyed by uppercase xa hex */
+    borderRouters?: ReadonlyMap<string, BorderRouterEntry>;
+    hideOfflineNodes?: boolean;
+    hideWeakSignalEdges?: boolean;
+    hideMediumSignalEdges?: boolean;
+    hideStrongSignalEdges?: boolean;
+}
+
+class ThreadGraph extends BaseNetworkGraph<ThreadGraphProps, BaseNetworkGraphState> {
+    componentDidUpdate(prevProps: ThreadGraphProps): void {
+        super.componentDidUpdate(prevProps);
+        // BaseNetworkGraph only watches `nodes`/`darkMode`/`selectedNodeId`; rebuild also when the
+        // BR registry refreshes or any hide option changes (otherwise stale labels/icons/edges).
+        if (
+            prevProps.borderRouters !== this.props.borderRouters ||
+            prevProps.hideOfflineNodes !== this.props.hideOfflineNodes ||
+            prevProps.hideWeakSignalEdges !== this.props.hideWeakSignalEdges ||
+            prevProps.hideMediumSignalEdges !== this.props.hideMediumSignalEdges ||
+            prevProps.hideStrongSignalEdges !== this.props.hideStrongSignalEdges
+        ) {
+            this.updateGraph();
+        }
+    }
+
     protected updateGraph(): void {
         if (!this.nodesDataSet || !this.edgesDataSet) {
             return;
         }
 
-        // Clear stored edge colors since we're rebuilding the graph
         this.clearOriginalEdgeColors();
 
-        const { nodes: allNodes, darkMode } = this.props;
+        const { nodes: allNodes, darkMode, borderRouters } = this.props;
+        const hideOfflineNodes = this.props.hideOfflineNodes ?? false;
+        const hideWeakSignalEdges = this.props.hideWeakSignalEdges ?? false;
+        const hideMediumSignalEdges = this.props.hideMediumSignalEdges ?? false;
+        const hideStrongSignalEdges = this.props.hideStrongSignalEdges ?? false;
 
-        // Filter Thread nodes
         const threadNodes = allNodes.filter(n => n.networkType === 'thread');
 
-        // Build address maps for matching
         const extAddrMap = buildExtAddrMap(threadNodes);
         const rloc16Map = buildRloc16Map(threadNodes);
 
-        // Find unknown devices in neighbor tables (computed locally, not stored in state)
-        const unknownDevices = findUnknownDevices(threadNodes, extAddrMap, rloc16Map);
+        // External devices (seen in neighbor tables but not commissioned), classified against the
+        // BR registry so mDNS-known routers render distinctly.
+        const externalDevices = findUnknownDevices(threadNodes, extAddrMap, rloc16Map, borderRouters);
 
-        // Build connections
-        const connections = buildThreadConnections(threadNodes, extAddrMap, unknownDevices, rloc16Map);
+        const connections = buildThreadConnections(threadNodes, extAddrMap, externalDevices, rloc16Map);
 
-        // Create graph nodes
         const graphNodes: NetworkGraphNode[] = [];
+        const hiddenNodeIds = new Set<string>();
 
-        // Add known Thread devices
+        // Known Thread devices
         for (const node of threadNodes) {
             const role = node.thread?.routingRole as ThreadRoutingRole | null;
             const roleName = getThreadRoleName(role);
             const extAddrHex = node.thread?.extendedAddress
                 ? parseExtendedAddressToHex(node.thread.extendedAddress)
                 : '';
+            const isOffline = !node.isConnected;
+            const shouldHide = hideOfflineNodes && isOffline;
+            if (shouldHide) {
+                hiddenNodeIds.add(node.nodeId);
+            }
 
             graphNodes.push({
                 id: node.nodeId,
                 label: node.name,
-                shape: 'dot',
-                size: this.getNodeSize(role),
-                color: this.getThreadNodeColor(node.isConnected, role),
+                shape: 'image',
+                image: createNodeIconDataUrl(node.deviceType, role, isOffline),
+                size: 24,
                 font: { color: darkMode ? '#e0e0e0' : '#333333' },
-                title: `${node.name}\nRole: ${roleName}\nAddress: ${extAddrHex}\n${node.isConnected ? 'Connected' : 'Offline'}`,
+                title: `${node.name}\nRole: ${roleName}\nAddress: ${extAddrHex}\n${isOffline ? 'Offline' : 'Connected'}`,
                 networkType: 'thread',
                 threadRole: role ?? undefined,
-                offline: !node.isConnected,
+                offline: isOffline,
+                hidden: shouldHide,
             });
         }
 
-        // Add external devices (genuinely not on our fabric)
-        for (const unknown of unknownDevices) {
-            const externalLabel = unknown.isRouter ? 'External Router' : 'External Device';
-            graphNodes.push({
-                id: unknown.id,
-                label: `${externalLabel}\n${unknown.extAddressHex.slice(-8)}`,
-                shape: 'dot',
-                size: 12,
-                color: {
-                    background: '#FFC107',
-                    border: '#FFA000',
-                },
-                font: { color: darkMode ? '#e0e0e0' : '#333333' },
-                title: `${externalLabel}\nAddress: ${unknown.extAddressHex}\nSeen by: ${unknown.seenBy.length} device(s)`,
-                networkType: 'thread',
-                isUnknown: true,
-            });
-        }
-
-        // Build a map of nodeId -> isConnected for checking offline status
+        // Status map for offline-cascade on edges
         const nodeConnectionStatus = new Map<string, boolean>();
         for (const node of threadNodes) {
             nodeConnectionStatus.set(node.nodeId, node.isConnected);
         }
+        const neighborCount = new Map<string, number>();
+        for (const node of threadNodes) {
+            neighborCount.set(node.nodeId, node.thread?.neighborTable?.length ?? 0);
+        }
 
-        // Create graph edges
-        const graphEdges: NetworkGraphEdge[] = connections.map((conn, index) => {
-            // Check if either endpoint is offline - dashed lines indicate stale data
+        // External devices: known Border Routers (friendly label/icon) vs unidentified neighbors
+        for (const device of externalDevices) {
+            const hasOnlineObserver = device.seenBy.some(id => nodeConnectionStatus.get(id) === true);
+
+            // Unknown externals are pure neighbor-table inference. Two stale-cache signatures we
+            // always filter: (1) every observer offline (can't re-confirm); (2) a single observer
+            // that has other neighbors (single-source ghost from an otherwise-reachable node).
+            // BRs have independent mDNS evidence — honor only the user toggle for them.
+            let shouldHide: boolean;
+            if (device.kind === 'unknown') {
+                shouldHide = !hasOnlineObserver;
+                if (!shouldHide && device.seenBy.length === 1 && (neighborCount.get(device.seenBy[0]) ?? 0) > 1) {
+                    shouldHide = true;
+                }
+            } else {
+                shouldHide = hideOfflineNodes && !hasOnlineObserver;
+            }
+            if (shouldHide) {
+                hiddenNodeIds.add(device.id);
+            }
+
+            if (device.kind === 'br') {
+                const hostname = device.hostname !== undefined ? stripMdnsHostname(device.hostname) : undefined;
+                const top = (hostname ?? device.networkName ?? 'Border Router').slice(0, 24);
+                const suffix =
+                    hostname !== undefined && device.networkName !== undefined && device.networkName !== top
+                        ? `\n${device.networkName}`
+                        : '';
+                const decoded = decodeMeshcopStateBitmap(device.stateBitmapHex);
+                const isLeader = decoded?.threadRoleValue === 3;
+                const isPrimaryBbr = decoded?.bbr === true && decoded.bbrFunction === 'primary';
+                const tooltip = [
+                    device.networkName ? `Network: ${device.networkName}` : undefined,
+                    device.vendorName ? `Vendor: ${device.vendorName}` : undefined,
+                    device.threadVersion ? `Thread: ${device.threadVersion}` : undefined,
+                    device.addresses.length ? `Addresses:\n  ${device.addresses.join('\n  ')}` : undefined,
+                    device.sources.length === 0 ? '(stale)' : undefined,
+                ]
+                    .filter(Boolean)
+                    .join('\n');
+                graphNodes.push({
+                    id: device.id,
+                    label: `${top}${suffix}`,
+                    shape: 'image',
+                    image: createBorderRouterIconDataUrl(false, isLeader, isPrimaryBbr),
+                    size: 26,
+                    font: { color: darkMode ? '#e0e0e0' : '#333333' },
+                    title: tooltip || (hostname ?? 'Border Router'),
+                    networkType: 'thread',
+                    hidden: shouldHide,
+                });
+            } else {
+                const typeLabel = device.isRouter ? 'External Router' : 'External Device';
+                const suffix = device.networkName !== undefined ? `\n${device.networkName}` : '';
+                graphNodes.push({
+                    id: device.id,
+                    label: `${typeLabel} (${device.extAddressHex.slice(-8)})${suffix}`,
+                    shape: 'image',
+                    image: createUnknownDeviceIconDataUrl(device.isRouter),
+                    size: 20,
+                    font: { color: darkMode ? '#e0e0e0' : '#333333' },
+                    title: `${typeLabel}\nAddress: ${device.extAddressHex}\nSeen by: ${device.seenBy.length} device(s)`,
+                    networkType: 'thread',
+                    isUnknown: true,
+                    hidden: shouldHide,
+                });
+            }
+        }
+
+        // Edges
+        const graphEdges: NetworkGraphEdge[] = [];
+        connections.forEach((conn, index) => {
+            const level = getSignalLevelFromLqi(conn.lqi);
             const fromOffline = nodeConnectionStatus.get(conn.fromNodeId) === false;
             const toOffline = nodeConnectionStatus.get(conn.toNodeId) === false;
             const hasOfflineEndpoint = fromOffline || toOffline;
 
-            // Build tooltip with enhanced route table data
+            // No-link (LQI=0) edges are never drawn; apply signal-level filters + offline cascade.
+            let hidden = level === 'none';
+            if (!hidden && (hiddenNodeIds.has(conn.fromNodeId) || hiddenNodeIds.has(conn.toNodeId))) {
+                hidden = true;
+            }
+            if (!hidden && hideWeakSignalEdges && level === 'weak') {
+                hidden = true;
+            }
+            if (!hidden && hideMediumSignalEdges && level === 'medium') {
+                hidden = true;
+            }
+            if (!hidden && hideStrongSignalEdges && level === 'strong') {
+                hidden = true;
+            }
+
             const tooltipLines: string[] = [];
             if (conn.rssi !== null) {
                 tooltipLines.push(`RSSI: ${conn.rssi} dBm`);
@@ -111,83 +215,83 @@ class ThreadGraph extends BaseNetworkGraph<BaseNetworkGraphProps, BaseNetworkGra
                 tooltipLines.push('(Route table only)');
             }
 
-            return {
+            graphEdges.push({
                 id: `edge_${index}`,
                 from: conn.fromNodeId,
                 to: conn.toNodeId,
-                color: {
-                    color: conn.signalColor.color,
-                    highlight: conn.signalColor.highlight,
-                },
+                color: { color: conn.signalColor.color, highlight: conn.signalColor.highlight },
                 width: 2,
                 title: tooltipLines.join('\n'),
                 dashes: conn.isUnknown || hasOfflineEndpoint || conn.fromRouteTable,
-            };
+                hidden,
+            });
         });
 
-        // Update datasets
         this.nodesDataSet.clear();
         this.nodesDataSet.add(graphNodes);
-
         this.edgesDataSet.clear();
         this.edgesDataSet.add(graphEdges);
     }
 
-    // eslint-disable-next-line class-methods-use-this
-    private getNodeSize(role: ThreadRoutingRole | null): number {
-        switch (role) {
-            case 6: // Leader
-                return 22;
-            case 5: // Router
-                return 18;
-            case 4: // REED
-                return 16;
-            default:
-                return 14;
+    /**
+     * Selects a Thread node (known device or external) matching the query, in priority order:
+     * extended address (EUI-64; accepts `AABB...`, `AA:BB:...`, `0x...`), exact node id, then a
+     * case-insensitive device-name substring. Returns the matched id, or null when nothing matches.
+     */
+    public findNodeBySearch(query: string): string | null {
+        const trimmed = query.trim();
+        if (!trimmed) {
+            return null;
         }
-    }
+        const { nodes: allNodes, borderRouters } = this.props;
+        const hideOfflineNodes = this.props.hideOfflineNodes ?? false;
+        const threadNodes = allNodes.filter(n => n.networkType === 'thread' && !(hideOfflineNodes && !n.isConnected));
 
-    // eslint-disable-next-line class-methods-use-this
-    private getThreadNodeColor(
-        isConnected: boolean,
-        role: ThreadRoutingRole | null,
-    ): { background: string; border: string } {
-        if (!isConnected) {
-            return {
-                background: '#9E9E9E',
-                border: '#616161',
-            };
+        const normalized = normalizeExtendedAddressInput(trimmed);
+        if (normalized) {
+            for (const node of threadNodes) {
+                const hex = node.thread?.extendedAddress ? parseExtendedAddressToHex(node.thread.extendedAddress) : '';
+                if (hex === normalized) {
+                    return node.nodeId;
+                }
+            }
+            const extAddrMap = buildExtAddrMap(threadNodes);
+            const rloc16Map = buildRloc16Map(threadNodes);
+            const externalDevices = findUnknownDevices(threadNodes, extAddrMap, rloc16Map, borderRouters);
+            for (const device of externalDevices) {
+                if (device.extAddressHex === normalized) {
+                    return device.id;
+                }
+            }
         }
 
-        switch (role) {
-            case 6: // Leader
-                return {
-                    background: '#9C27B0',
-                    border: '#6A1B9A',
-                };
-            case 5: // Router
-                return {
-                    background: '#2196F3',
-                    border: '#1565C0',
-                };
-            case 4: // REED
-                return {
-                    background: '#03A9F4',
-                    border: '#0288D1',
-                };
-            case 3: // End Device
-            case 2: // Sleepy End Device
-                return {
-                    background: '#4CAF50',
-                    border: '#2E7D32',
-                };
-            default:
-                return {
-                    background: '#607D8B',
-                    border: '#455A64',
-                };
+        for (const node of threadNodes) {
+            if (node.nodeId === trimmed) {
+                return node.nodeId;
+            }
         }
+
+        const needle = trimmed.toLowerCase();
+        for (const node of threadNodes) {
+            if (node.name.toLowerCase().includes(needle)) {
+                return node.nodeId;
+            }
+        }
+        return null;
     }
+}
+
+function normalizeExtendedAddressInput(address: string): string | null {
+    const trimmed = address.trim();
+    if (!trimmed) {
+        return null;
+    }
+    const noPrefix = trimmed.startsWith('0x') || trimmed.startsWith('0X') ? trimmed.slice(2) : trimmed;
+    const hexOnly = noPrefix.replace(/[^a-fA-F0-9]/g, '');
+    if (hexOnly.length !== 16) {
+        return null;
+    }
+    return hexOnly.toUpperCase();
 }
 
 export default ThreadGraph;

--- a/src-admin/src/components/network/ThreadGraph.tsx
+++ b/src-admin/src/components/network/ThreadGraph.tsx
@@ -3,6 +3,7 @@
  * Shows Thread devices, Border Routers and their mesh connections with signal quality
  */
 
+import { I18n } from '@iobroker/adapter-react-v5';
 import BaseNetworkGraph, { type BaseNetworkGraphProps, type BaseNetworkGraphState } from './BaseNetworkGraph';
 import type { NetworkGraphNode, NetworkGraphEdge, ThreadRoutingRole, BorderRouterEntry } from './NetworkTypes';
 import {
@@ -90,7 +91,7 @@ class ThreadGraph extends BaseNetworkGraph<ThreadGraphProps, BaseNetworkGraphSta
                 image: createNodeIconDataUrl(node.deviceType, role, isOffline),
                 size: 24,
                 font: { color: darkMode ? '#e0e0e0' : '#333333' },
-                title: `${node.name}\nRole: ${roleName}\nAddress: ${extAddrHex}\n${isOffline ? 'Offline' : 'Connected'}`,
+                title: `${node.name}\n${I18n.t('Role')}: ${roleName}\n${I18n.t('Extended Address')}: ${extAddrHex}\n${isOffline ? I18n.t('Offline') : I18n.t('Connected')}`,
                 networkType: 'thread',
                 threadRole: role ?? undefined,
                 offline: isOffline,
@@ -131,7 +132,7 @@ class ThreadGraph extends BaseNetworkGraph<ThreadGraphProps, BaseNetworkGraphSta
 
             if (device.kind === 'br') {
                 const hostname = device.hostname !== undefined ? stripMdnsHostname(device.hostname) : undefined;
-                const top = (hostname ?? device.networkName ?? 'Border Router').slice(0, 24);
+                const top = (hostname ?? device.networkName ?? I18n.t('Border Router')).slice(0, 24);
                 const suffix =
                     hostname !== undefined && device.networkName !== undefined && device.networkName !== top
                         ? `\n${device.networkName}`
@@ -140,11 +141,11 @@ class ThreadGraph extends BaseNetworkGraph<ThreadGraphProps, BaseNetworkGraphSta
                 const isLeader = decoded?.threadRoleValue === 3;
                 const isPrimaryBbr = decoded?.bbr === true && decoded.bbrFunction === 'primary';
                 const tooltip = [
-                    device.networkName ? `Network: ${device.networkName}` : undefined,
-                    device.vendorName ? `Vendor: ${device.vendorName}` : undefined,
-                    device.threadVersion ? `Thread: ${device.threadVersion}` : undefined,
-                    device.addresses.length ? `Addresses:\n  ${device.addresses.join('\n  ')}` : undefined,
-                    device.sources.length === 0 ? '(stale)' : undefined,
+                    device.networkName ? `${I18n.t('Network')}: ${device.networkName}` : undefined,
+                    device.vendorName ? `${I18n.t('Vendor')}: ${device.vendorName}` : undefined,
+                    device.threadVersion ? `${I18n.t('Thread Version')}: ${device.threadVersion}` : undefined,
+                    device.addresses.length ? `${I18n.t('Addresses')}:\n  ${device.addresses.join('\n  ')}` : undefined,
+                    device.sources.length === 0 ? `(${I18n.t('stale')})` : undefined,
                 ]
                     .filter(Boolean)
                     .join('\n');
@@ -155,12 +156,12 @@ class ThreadGraph extends BaseNetworkGraph<ThreadGraphProps, BaseNetworkGraphSta
                     image: createBorderRouterIconDataUrl(false, isLeader, isPrimaryBbr),
                     size: 26,
                     font: { color: darkMode ? '#e0e0e0' : '#333333' },
-                    title: tooltip || (hostname ?? 'Border Router'),
+                    title: tooltip || (hostname ?? I18n.t('Border Router')),
                     networkType: 'thread',
                     hidden: shouldHide,
                 });
             } else {
-                const typeLabel = device.isRouter ? 'External Router' : 'External Device';
+                const typeLabel = device.isRouter ? I18n.t('External Router') : I18n.t('External Device');
                 const suffix = device.networkName !== undefined ? `\n${device.networkName}` : '';
                 graphNodes.push({
                     id: device.id,
@@ -169,7 +170,7 @@ class ThreadGraph extends BaseNetworkGraph<ThreadGraphProps, BaseNetworkGraphSta
                     image: createUnknownDeviceIconDataUrl(device.isRouter),
                     size: 20,
                     font: { color: darkMode ? '#e0e0e0' : '#333333' },
-                    title: `${typeLabel}\nAddress: ${device.extAddressHex}\nSeen by: ${device.seenBy.length} device(s)`,
+                    title: `${typeLabel}\n${I18n.t('Extended Address')}: ${device.extAddressHex}\n${I18n.t('Seen by')}: ${device.seenBy.length}`,
                     networkType: 'thread',
                     isUnknown: true,
                     hidden: shouldHide,
@@ -206,13 +207,13 @@ class ThreadGraph extends BaseNetworkGraph<ThreadGraphProps, BaseNetworkGraphSta
             }
             tooltipLines.push(`LQI: ${conn.lqi}`);
             if (conn.bidirectionalLqi !== undefined) {
-                tooltipLines.push(`Bidirectional LQI: ${conn.bidirectionalLqi}`);
+                tooltipLines.push(`${I18n.t('Bidirectional LQI')}: ${conn.bidirectionalLqi}`);
             }
             if (conn.pathCost !== undefined) {
-                tooltipLines.push(`Path Cost: ${conn.pathCost}`);
+                tooltipLines.push(`${I18n.t('Path Cost')}: ${conn.pathCost}`);
             }
             if (conn.fromRouteTable) {
-                tooltipLines.push('(Route table only)');
+                tooltipLines.push(`(${I18n.t('Route table only')})`);
             }
 
             graphEdges.push({

--- a/src-admin/src/components/network/WiFiGraph.tsx
+++ b/src-admin/src/components/network/WiFiGraph.tsx
@@ -12,6 +12,7 @@ import {
     getWiFiSecurityTypeName,
     getWiFiVersionName,
 } from './NetworkUtils';
+import { createNodeIconDataUrl, createWiFiApIconDataUrl } from './NetworkIcons';
 
 class WiFiGraph extends BaseNetworkGraph<BaseNetworkGraphProps, BaseNetworkGraphState> {
     // eslint-disable-next-line class-methods-use-this
@@ -55,17 +56,15 @@ class WiFiGraph extends BaseNetworkGraph<BaseNetworkGraphProps, BaseNetworkGraph
         // Create graph nodes
         const graphNodes: NetworkGraphNode[] = [];
 
-        // Add access point nodes
+        // Add access point nodes — full BSSID in the label so dual-band radios that differ only in
+        // leading octets don't collapse into a single AP visually.
         for (const ap of accessPoints) {
             graphNodes.push({
                 id: `ap_${ap.bssid}`,
-                label: `AP\n${ap.bssidFormatted}`,
-                shape: 'dot',
-                size: 20,
-                color: {
-                    background: '#FF5722',
-                    border: '#D84315',
-                },
+                label: `AP ${ap.bssidFormatted}`,
+                shape: 'image',
+                image: createWiFiApIconDataUrl(),
+                size: 26,
                 font: { color: darkMode ? '#e0e0e0' : '#333333' },
                 title: `Access Point\nBSSID: ${ap.bssidFormatted}\nConnected devices: ${ap.connectedNodes.length}`,
                 networkType: 'wifi',
@@ -79,17 +78,18 @@ class WiFiGraph extends BaseNetworkGraph<BaseNetworkGraphProps, BaseNetworkGraph
             const wifiVersion = getWiFiVersionName(node.wifi?.wifiVersion ?? null);
             const rssi = node.wifi?.rssi ?? null;
             const channel = node.wifi?.channel ?? null;
+            const isOffline = !node.isConnected;
 
             graphNodes.push({
                 id: node.nodeId,
                 label: node.name,
-                shape: 'dot',
-                size: 14,
-                color: this.getWiFiNodeColor(node.isConnected, rssi),
+                shape: 'image',
+                image: createNodeIconDataUrl(node.deviceType, null, isOffline),
+                size: 24,
                 font: { color: darkMode ? '#e0e0e0' : '#333333' },
                 title: `${node.name}\n${node.isConnected ? 'Connected' : 'Offline'}${rssi !== null ? `\nRSSI: ${rssi} dBm` : ''}${channel !== null ? `\nChannel: ${channel}` : ''}\nSecurity: ${securityType}\nWiFi: ${wifiVersion}`,
                 networkType: 'wifi',
-                offline: !node.isConnected,
+                offline: isOffline,
             });
         }
 
@@ -127,45 +127,6 @@ class WiFiGraph extends BaseNetworkGraph<BaseNetworkGraphProps, BaseNetworkGraph
 
         this.edgesDataSet.clear();
         this.edgesDataSet.add(graphEdges);
-    }
-
-    // eslint-disable-next-line class-methods-use-this
-    private getWiFiNodeColor(isConnected: boolean, rssi: number | null): { background: string; border: string } {
-        if (!isConnected) {
-            return {
-                background: '#9E9E9E',
-                border: '#616161',
-            };
-        }
-
-        // Color based on signal strength
-        const signalColor = getSignalColorFromRssi(rssi);
-        if (signalColor.color === '#4CAF50') {
-            // Strong
-            return {
-                background: '#4CAF50',
-                border: '#2E7D32',
-            };
-        }
-        if (signalColor.color === '#FF9800') {
-            // Medium
-            return {
-                background: '#FF9800',
-                border: '#EF6C00',
-            };
-        }
-        if (signalColor.color === '#F44336') {
-            // Weak
-            return {
-                background: '#F44336',
-                border: '#C62828',
-            };
-        }
-        // Unknown - use orange/amber to match Thread unknown devices
-        return {
-            background: '#FFC107',
-            border: '#FFA000',
-        };
     }
 }
 

--- a/src-admin/src/components/network/WiFiGraph.tsx
+++ b/src-admin/src/components/network/WiFiGraph.tsx
@@ -13,6 +13,7 @@ import {
     getWiFiVersionName,
 } from './NetworkUtils';
 import { createNodeIconDataUrl, createWiFiApIconDataUrl } from './NetworkIcons';
+import { I18n } from '@iobroker/adapter-react-v5';
 
 class WiFiGraph extends BaseNetworkGraph<BaseNetworkGraphProps, BaseNetworkGraphState> {
     // eslint-disable-next-line class-methods-use-this
@@ -66,7 +67,7 @@ class WiFiGraph extends BaseNetworkGraph<BaseNetworkGraphProps, BaseNetworkGraph
                 image: createWiFiApIconDataUrl(),
                 size: 26,
                 font: { color: darkMode ? '#e0e0e0' : '#333333' },
-                title: `Access Point\nBSSID: ${ap.bssidFormatted}\nConnected devices: ${ap.connectedNodes.length}`,
+                title: `${I18n.t('Access Point')}\n${I18n.t('BSSID')}: ${ap.bssidFormatted}\n${I18n.t('Connected devices')}: ${ap.connectedNodes.length}`,
                 networkType: 'wifi',
                 isAccessPoint: true,
             });
@@ -87,7 +88,7 @@ class WiFiGraph extends BaseNetworkGraph<BaseNetworkGraphProps, BaseNetworkGraph
                 image: createNodeIconDataUrl(node.deviceType, null, isOffline),
                 size: 24,
                 font: { color: darkMode ? '#e0e0e0' : '#333333' },
-                title: `${node.name}\n${node.isConnected ? 'Connected' : 'Offline'}${rssi !== null ? `\nRSSI: ${rssi} dBm` : ''}${channel !== null ? `\nChannel: ${channel}` : ''}\nSecurity: ${securityType}\nWiFi: ${wifiVersion}`,
+                title: `${node.name}\n${node.isConnected ? I18n.t('Connected') : I18n.t('Offline')}${rssi !== null ? `\nRSSI: ${rssi} dBm` : ''}${channel !== null ? `\n${I18n.t('Channel')}: ${channel}` : ''}\n${I18n.t('Security')}: ${securityType}\n${I18n.t('WiFi Version')}: ${wifiVersion}`,
                 networkType: 'wifi',
                 offline: isOffline,
             });
@@ -116,7 +117,7 @@ class WiFiGraph extends BaseNetworkGraph<BaseNetworkGraphProps, BaseNetworkGraph
                     highlight: signalColor.highlight,
                 },
                 width: 2,
-                title: rssi !== null ? `RSSI: ${rssi} dBm` : 'Signal: Unknown',
+                title: rssi !== null ? `RSSI: ${rssi} dBm` : I18n.t('Signal: Unknown'),
                 dashes: isOffline,
             });
         }

--- a/src-admin/src/components/network/index.ts
+++ b/src-admin/src/components/network/index.ts
@@ -12,3 +12,4 @@ export type { SelectedNodeType } from './UpdateConnectionsDialog';
 
 export * from './NetworkTypes';
 export * from './NetworkUtils';
+export * from './NetworkIcons';

--- a/src-admin/src/globals.d.ts
+++ b/src-admin/src/globals.d.ts
@@ -2,6 +2,7 @@ declare global {
     declare module '*.svg';
     declare module '*.png';
     declare module '*.jpg';
+    declare module '*.css';
 
     declare module '@mui/material/Button' {
         interface ButtonPropsColorOverrides {

--- a/src-admin/src/i18n/de.json
+++ b/src-admin/src/i18n/de.json
@@ -285,5 +285,18 @@
     "Hide strong links": "Starke Verbindungen ausblenden",
     "Hide weak links": "Schwache Verbindungen ausblenden",
     "Search mesh": "Mesh durchsuchen",
-    "Thread Version": "Thread-Version"
+    "Thread Version": "Thread-Version",
+    "Network": "Netzwerk",
+    "Vendor": "Hersteller",
+    "Model": "Modell",
+    "Partition": "Partition",
+    "Addresses": "Adressen",
+    "Seen by": "Gesehen von",
+    "Border Agent": "Border Agent",
+    "Detached": "Getrennt",
+    "Child": "Child",
+    "primary": "primär",
+    "secondary": "sekundär",
+    "External Router": "Externer Router",
+    "External Device": "Externes Gerät"
 }

--- a/src-admin/src/i18n/de.json
+++ b/src-admin/src/i18n/de.json
@@ -275,5 +275,15 @@
     "status_disconnected": "Getrennt",
     "status_waitingForCommissioning": "Warten auf die Inbetriebnahme",
     "status_waitingForDeviceDiscovery": "Warten auf Geräteerkennung",
-    "to bridge": "überbrücken"
+    "to bridge": "überbrücken",
+    "BSSID": "BSSID",
+    "Border Router": "Border Router",
+    "Click a node to see details": "Knoten anklicken für Details",
+    "Filter": "Filter",
+    "Hide medium links": "Mittlere Verbindungen ausblenden",
+    "Hide offline nodes": "Offline-Knoten ausblenden",
+    "Hide strong links": "Starke Verbindungen ausblenden",
+    "Hide weak links": "Schwache Verbindungen ausblenden",
+    "Search mesh": "Mesh durchsuchen",
+    "Thread Version": "Thread-Version"
 }

--- a/src-admin/src/i18n/de.json
+++ b/src-admin/src/i18n/de.json
@@ -298,5 +298,11 @@
     "primary": "primär",
     "secondary": "sekundär",
     "External Router": "Externer Router",
-    "External Device": "Externes Gerät"
+    "External Device": "Externes Gerät",
+    "Bidirectional LQI": "Bidirektionaler LQI",
+    "Path Cost": "Pfadkosten",
+    "Route table only": "Nur Routing-Tabelle",
+    "Connected devices": "Verbundene Geräte",
+    "Signal: Unknown": "Signal: Unbekannt",
+    "stale": "veraltet"
 }

--- a/src-admin/src/i18n/en.json
+++ b/src-admin/src/i18n/en.json
@@ -285,5 +285,18 @@
     "Hide strong links": "Hide strong links",
     "Hide weak links": "Hide weak links",
     "Search mesh": "Search mesh",
-    "Thread Version": "Thread Version"
+    "Thread Version": "Thread Version",
+    "Network": "Network",
+    "Vendor": "Vendor",
+    "Model": "Model",
+    "Partition": "Partition",
+    "Addresses": "Addresses",
+    "Seen by": "Seen by",
+    "Border Agent": "Border Agent",
+    "Detached": "Detached",
+    "Child": "Child",
+    "primary": "primary",
+    "secondary": "secondary",
+    "External Router": "External Router",
+    "External Device": "External Device"
 }

--- a/src-admin/src/i18n/en.json
+++ b/src-admin/src/i18n/en.json
@@ -298,5 +298,11 @@
     "primary": "primary",
     "secondary": "secondary",
     "External Router": "External Router",
-    "External Device": "External Device"
+    "External Device": "External Device",
+    "Bidirectional LQI": "Bidirectional LQI",
+    "Path Cost": "Path Cost",
+    "Route table only": "Route table only",
+    "Connected devices": "Connected devices",
+    "Signal: Unknown": "Signal: Unknown",
+    "stale": "stale"
 }

--- a/src-admin/src/i18n/en.json
+++ b/src-admin/src/i18n/en.json
@@ -275,5 +275,15 @@
     "status_disconnected": "Disconnected",
     "status_waitingForCommissioning": "Waiting for commissioning",
     "status_waitingForDeviceDiscovery": "Waiting for device discovery",
-    "to bridge": "to bridge"
+    "to bridge": "to bridge",
+    "BSSID": "BSSID",
+    "Border Router": "Border Router",
+    "Click a node to see details": "Click a node to see details",
+    "Filter": "Filter",
+    "Hide medium links": "Hide medium links",
+    "Hide offline nodes": "Hide offline nodes",
+    "Hide strong links": "Hide strong links",
+    "Hide weak links": "Hide weak links",
+    "Search mesh": "Search mesh",
+    "Thread Version": "Thread Version"
 }

--- a/src-admin/src/i18n/es.json
+++ b/src-admin/src/i18n/es.json
@@ -275,5 +275,11 @@
     "primary": "primario",
     "secondary": "secundario",
     "External Router": "Router externo",
-    "External Device": "Dispositivo externo"
+    "External Device": "Dispositivo externo",
+    "Bidirectional LQI": "LQI bidireccional",
+    "Path Cost": "Costo de ruta",
+    "Route table only": "Solo tabla de rutas",
+    "Connected devices": "Dispositivos conectados",
+    "Signal: Unknown": "Señal: desconocida",
+    "stale": "obsoleto"
 }

--- a/src-admin/src/i18n/es.json
+++ b/src-admin/src/i18n/es.json
@@ -170,7 +170,7 @@
     "Reset to defaults": "Restablecer los valores predeterminados",
     "Reset to factory defaults": "Restablecer los valores predeterminados de fábrica",
     "Room plus device type names": "Nombres de tipo de habitación y dispositivo",
-    "Router": "Enrutador",
+    "Router": "Router",
     "Save": "Ahorrar",
     "Scan with the ioBroker cloud": "Escanee con la nube ioBroker",
     "Select default bridge": "Seleccionar puente predeterminado",
@@ -252,5 +252,15 @@
     "status_disconnected": "Desconectado",
     "status_waitingForCommissioning": "Esperando puesta en marcha",
     "status_waitingForDeviceDiscovery": "Esperando el descubrimiento del dispositivo",
-    "to bridge": "al puente"
+    "to bridge": "al puente",
+    "BSSID": "BSSID",
+    "Border Router": "Router de borde",
+    "Click a node to see details": "Haga clic en un nodo para ver los detalles",
+    "Filter": "Filtro",
+    "Hide medium links": "Ocultar enlaces medios",
+    "Hide offline nodes": "Ocultar nodos sin conexión",
+    "Hide strong links": "Ocultar enlaces fuertes",
+    "Hide weak links": "Ocultar enlaces débiles",
+    "Search mesh": "Buscar en la malla",
+    "Thread Version": "Versión de Thread"
 }

--- a/src-admin/src/i18n/es.json
+++ b/src-admin/src/i18n/es.json
@@ -262,5 +262,18 @@
     "Hide strong links": "Ocultar enlaces fuertes",
     "Hide weak links": "Ocultar enlaces débiles",
     "Search mesh": "Buscar en la malla",
-    "Thread Version": "Versión de Thread"
+    "Thread Version": "Versión de Thread",
+    "Network": "Red",
+    "Vendor": "Fabricante",
+    "Model": "Modelo",
+    "Partition": "Partición",
+    "Addresses": "Direcciones",
+    "Seen by": "Visto por",
+    "Border Agent": "Border Agent",
+    "Detached": "Desvinculado",
+    "Child": "Hijo",
+    "primary": "primario",
+    "secondary": "secundario",
+    "External Router": "Router externo",
+    "External Device": "Dispositivo externo"
 }

--- a/src-admin/src/i18n/fr.json
+++ b/src-admin/src/i18n/fr.json
@@ -108,7 +108,7 @@
     "Info about Alexa Bridge": "Remarque : en raison des limitations du système Amazon Alexa, un seul pont ou appareil peut être associé à Alexa par hôte ioBroker ! Cette sélection détermine quel pont sera associé au système Alexa.",
     "Instance is not alive": "L'instance n'est pas vivante",
     "Interface": "Interface",
-    "Leader": "Responsable",
+    "Leader": "Leader",
     "Length of manual code must be 11 or 21 characters": "La longueur du code manuel doit être de 11 ou 21 caractères",
     "Logging": "Enregistrement",
     "Login and password will not be taken as incomplete. Discard changes?": "Le login et le mot de passe ne seront pas considérés comme incomplets. Annuler les modifications ?",
@@ -252,5 +252,15 @@
     "status_disconnected": "Débranché",
     "status_waitingForCommissioning": "En attente de mise en service",
     "status_waitingForDeviceDiscovery": "En attente de découverte de périphérique",
-    "to bridge": "ponter"
+    "to bridge": "ponter",
+    "BSSID": "BSSID",
+    "Border Router": "Routeur de bordure",
+    "Click a node to see details": "Cliquez sur un nœud pour voir les détails",
+    "Filter": "Filtre",
+    "Hide medium links": "Masquer les liens moyens",
+    "Hide offline nodes": "Masquer les nœuds hors ligne",
+    "Hide strong links": "Masquer les liens forts",
+    "Hide weak links": "Masquer les liens faibles",
+    "Search mesh": "Rechercher dans le maillage",
+    "Thread Version": "Version Thread"
 }

--- a/src-admin/src/i18n/fr.json
+++ b/src-admin/src/i18n/fr.json
@@ -262,5 +262,18 @@
     "Hide strong links": "Masquer les liens forts",
     "Hide weak links": "Masquer les liens faibles",
     "Search mesh": "Rechercher dans le maillage",
-    "Thread Version": "Version Thread"
+    "Thread Version": "Version Thread",
+    "Network": "Réseau",
+    "Vendor": "Fabricant",
+    "Model": "Modèle",
+    "Partition": "Partition",
+    "Addresses": "Adresses",
+    "Seen by": "Vu par",
+    "Border Agent": "Border Agent",
+    "Detached": "Détaché",
+    "Child": "Enfant",
+    "primary": "primaire",
+    "secondary": "secondaire",
+    "External Router": "Routeur externe",
+    "External Device": "Appareil externe"
 }

--- a/src-admin/src/i18n/fr.json
+++ b/src-admin/src/i18n/fr.json
@@ -275,5 +275,11 @@
     "primary": "primaire",
     "secondary": "secondaire",
     "External Router": "Routeur externe",
-    "External Device": "Appareil externe"
+    "External Device": "Appareil externe",
+    "Bidirectional LQI": "LQI bidirectionnel",
+    "Path Cost": "Coût du chemin",
+    "Route table only": "Table de routage uniquement",
+    "Connected devices": "Appareils connectés",
+    "Signal: Unknown": "Signal : inconnu",
+    "stale": "obsolète"
 }

--- a/src-admin/src/i18n/it.json
+++ b/src-admin/src/i18n/it.json
@@ -252,5 +252,15 @@
     "status_disconnected": "Disconnesso",
     "status_waitingForCommissioning": "In attesa della messa in servizio",
     "status_waitingForDeviceDiscovery": "In attesa del rilevamento del dispositivo",
-    "to bridge": "collegare"
+    "to bridge": "collegare",
+    "BSSID": "BSSID",
+    "Border Router": "Border Router",
+    "Click a node to see details": "Fai clic su un nodo per i dettagli",
+    "Filter": "Filtro",
+    "Hide medium links": "Nascondi collegamenti medi",
+    "Hide offline nodes": "Nascondi nodi offline",
+    "Hide strong links": "Nascondi collegamenti forti",
+    "Hide weak links": "Nascondi collegamenti deboli",
+    "Search mesh": "Cerca nella rete",
+    "Thread Version": "Versione Thread"
 }

--- a/src-admin/src/i18n/it.json
+++ b/src-admin/src/i18n/it.json
@@ -262,5 +262,18 @@
     "Hide strong links": "Nascondi collegamenti forti",
     "Hide weak links": "Nascondi collegamenti deboli",
     "Search mesh": "Cerca nella rete",
-    "Thread Version": "Versione Thread"
+    "Thread Version": "Versione Thread",
+    "Network": "Rete",
+    "Vendor": "Produttore",
+    "Model": "Modello",
+    "Partition": "Partizione",
+    "Addresses": "Indirizzi",
+    "Seen by": "Visto da",
+    "Border Agent": "Border Agent",
+    "Detached": "Distaccato",
+    "Child": "Figlio",
+    "primary": "primario",
+    "secondary": "secondario",
+    "External Router": "Router esterno",
+    "External Device": "Dispositivo esterno"
 }

--- a/src-admin/src/i18n/it.json
+++ b/src-admin/src/i18n/it.json
@@ -275,5 +275,11 @@
     "primary": "primario",
     "secondary": "secondario",
     "External Router": "Router esterno",
-    "External Device": "Dispositivo esterno"
+    "External Device": "Dispositivo esterno",
+    "Bidirectional LQI": "LQI bidirezionale",
+    "Path Cost": "Costo del percorso",
+    "Route table only": "Solo tabella di routing",
+    "Connected devices": "Dispositivi connessi",
+    "Signal: Unknown": "Segnale: sconosciuto",
+    "stale": "obsoleto"
 }

--- a/src-admin/src/i18n/nl.json
+++ b/src-admin/src/i18n/nl.json
@@ -275,5 +275,11 @@
     "primary": "primair",
     "secondary": "secundair",
     "External Router": "Externe router",
-    "External Device": "Extern apparaat"
+    "External Device": "Extern apparaat",
+    "Bidirectional LQI": "Bidirectionele LQI",
+    "Path Cost": "Padkosten",
+    "Route table only": "Alleen routeringstabel",
+    "Connected devices": "Verbonden apparaten",
+    "Signal: Unknown": "Signaal: onbekend",
+    "stale": "verouderd"
 }

--- a/src-admin/src/i18n/nl.json
+++ b/src-admin/src/i18n/nl.json
@@ -262,5 +262,18 @@
     "Hide strong links": "Sterke verbindingen verbergen",
     "Hide weak links": "Zwakke verbindingen verbergen",
     "Search mesh": "Mesh doorzoeken",
-    "Thread Version": "Thread-versie"
+    "Thread Version": "Thread-versie",
+    "Network": "Netwerk",
+    "Vendor": "Fabrikant",
+    "Model": "Model",
+    "Partition": "Partitie",
+    "Addresses": "Adressen",
+    "Seen by": "Gezien door",
+    "Border Agent": "Border Agent",
+    "Detached": "Losgekoppeld",
+    "Child": "Child",
+    "primary": "primair",
+    "secondary": "secundair",
+    "External Router": "Externe router",
+    "External Device": "Extern apparaat"
 }

--- a/src-admin/src/i18n/nl.json
+++ b/src-admin/src/i18n/nl.json
@@ -252,5 +252,15 @@
     "status_disconnected": "Losgekoppeld",
     "status_waitingForCommissioning": "Wachten op inbedrijfstelling",
     "status_waitingForDeviceDiscovery": "Wachten op apparaatdetectie",
-    "to bridge": "overbruggen"
+    "to bridge": "overbruggen",
+    "BSSID": "BSSID",
+    "Border Router": "Border Router",
+    "Click a node to see details": "Klik op een knooppunt voor details",
+    "Filter": "Filter",
+    "Hide medium links": "Gemiddelde verbindingen verbergen",
+    "Hide offline nodes": "Offline knooppunten verbergen",
+    "Hide strong links": "Sterke verbindingen verbergen",
+    "Hide weak links": "Zwakke verbindingen verbergen",
+    "Search mesh": "Mesh doorzoeken",
+    "Thread Version": "Thread-versie"
 }

--- a/src-admin/src/i18n/pl.json
+++ b/src-admin/src/i18n/pl.json
@@ -170,7 +170,7 @@
     "Reset to defaults": "Przywróć domyślne",
     "Reset to factory defaults": "Przywróć ustawienia fabryczne",
     "Room plus device type names": "Nazwy pomieszczeń i typów urządzeń",
-    "Router": "Ruter",
+    "Router": "Router",
     "Save": "Ratować",
     "Scan with the ioBroker cloud": "Skanuj za pomocą chmury ioBroker",
     "Select default bridge": "Wybierz domyślny most",
@@ -252,5 +252,15 @@
     "status_disconnected": "Bezładny",
     "status_waitingForCommissioning": "Oczekiwanie na uruchomienie",
     "status_waitingForDeviceDiscovery": "Oczekiwanie na wykrycie urządzenia",
-    "to bridge": "mostkować"
+    "to bridge": "mostkować",
+    "BSSID": "BSSID",
+    "Border Router": "Router brzegowy",
+    "Click a node to see details": "Kliknij węzeł, aby zobaczyć szczegóły",
+    "Filter": "Filtr",
+    "Hide medium links": "Ukryj średnie połączenia",
+    "Hide offline nodes": "Ukryj węzły offline",
+    "Hide strong links": "Ukryj silne połączenia",
+    "Hide weak links": "Ukryj słabe połączenia",
+    "Search mesh": "Przeszukaj sieć mesh",
+    "Thread Version": "Wersja Thread"
 }

--- a/src-admin/src/i18n/pl.json
+++ b/src-admin/src/i18n/pl.json
@@ -262,5 +262,18 @@
     "Hide strong links": "Ukryj silne połączenia",
     "Hide weak links": "Ukryj słabe połączenia",
     "Search mesh": "Przeszukaj sieć mesh",
-    "Thread Version": "Wersja Thread"
+    "Thread Version": "Wersja Thread",
+    "Network": "Sieć",
+    "Vendor": "Producent",
+    "Model": "Model",
+    "Partition": "Partycja",
+    "Addresses": "Adresy",
+    "Seen by": "Widziane przez",
+    "Border Agent": "Border Agent",
+    "Detached": "Odłączony",
+    "Child": "Dziecko",
+    "primary": "podstawowy",
+    "secondary": "zapasowy",
+    "External Router": "Router zewnętrzny",
+    "External Device": "Urządzenie zewnętrzne"
 }

--- a/src-admin/src/i18n/pl.json
+++ b/src-admin/src/i18n/pl.json
@@ -275,5 +275,11 @@
     "primary": "podstawowy",
     "secondary": "zapasowy",
     "External Router": "Router zewnętrzny",
-    "External Device": "Urządzenie zewnętrzne"
+    "External Device": "Urządzenie zewnętrzne",
+    "Bidirectional LQI": "Dwukierunkowy LQI",
+    "Path Cost": "Koszt trasy",
+    "Route table only": "Tylko tablica routingu",
+    "Connected devices": "Podłączone urządzenia",
+    "Signal: Unknown": "Sygnał: nieznany",
+    "stale": "nieaktualny"
 }

--- a/src-admin/src/i18n/pt.json
+++ b/src-admin/src/i18n/pt.json
@@ -262,5 +262,18 @@
     "Hide strong links": "Ocultar ligações fortes",
     "Hide weak links": "Ocultar ligações fracas",
     "Search mesh": "Pesquisar malha",
-    "Thread Version": "Versão do Thread"
+    "Thread Version": "Versão do Thread",
+    "Network": "Rede",
+    "Vendor": "Fabricante",
+    "Model": "Modelo",
+    "Partition": "Partição",
+    "Addresses": "Endereços",
+    "Seen by": "Visto por",
+    "Border Agent": "Border Agent",
+    "Detached": "Desanexado",
+    "Child": "Filho",
+    "primary": "primário",
+    "secondary": "secundário",
+    "External Router": "Roteador externo",
+    "External Device": "Dispositivo externo"
 }

--- a/src-admin/src/i18n/pt.json
+++ b/src-admin/src/i18n/pt.json
@@ -252,5 +252,15 @@
     "status_disconnected": "Desconectado",
     "status_waitingForCommissioning": "Aguardando comissionamento",
     "status_waitingForDeviceDiscovery": "Aguardando descoberta do dispositivo",
-    "to bridge": "fazer uma ponte"
+    "to bridge": "fazer uma ponte",
+    "BSSID": "BSSID",
+    "Border Router": "Roteador de borda",
+    "Click a node to see details": "Clique num nó para ver os detalhes",
+    "Filter": "Filtro",
+    "Hide medium links": "Ocultar ligações médias",
+    "Hide offline nodes": "Ocultar nós offline",
+    "Hide strong links": "Ocultar ligações fortes",
+    "Hide weak links": "Ocultar ligações fracas",
+    "Search mesh": "Pesquisar malha",
+    "Thread Version": "Versão do Thread"
 }

--- a/src-admin/src/i18n/pt.json
+++ b/src-admin/src/i18n/pt.json
@@ -275,5 +275,11 @@
     "primary": "primário",
     "secondary": "secundário",
     "External Router": "Roteador externo",
-    "External Device": "Dispositivo externo"
+    "External Device": "Dispositivo externo",
+    "Bidirectional LQI": "LQI bidirecional",
+    "Path Cost": "Custo do caminho",
+    "Route table only": "Apenas tabela de rotas",
+    "Connected devices": "Dispositivos conectados",
+    "Signal: Unknown": "Sinal: desconhecido",
+    "stale": "obsoleto"
 }

--- a/src-admin/src/i18n/ru.json
+++ b/src-admin/src/i18n/ru.json
@@ -262,5 +262,18 @@
     "Hide strong links": "Скрыть сильные соединения",
     "Hide weak links": "Скрыть слабые соединения",
     "Search mesh": "Поиск в сети",
-    "Thread Version": "Версия Thread"
+    "Thread Version": "Версия Thread",
+    "Network": "Сеть",
+    "Vendor": "Производитель",
+    "Model": "Модель",
+    "Partition": "Раздел",
+    "Addresses": "Адреса",
+    "Seen by": "Виден узлами",
+    "Border Agent": "Border Agent",
+    "Detached": "Отключён",
+    "Child": "Дочерний",
+    "primary": "основной",
+    "secondary": "резервный",
+    "External Router": "Внешний маршрутизатор",
+    "External Device": "Внешнее устройство"
 }

--- a/src-admin/src/i18n/ru.json
+++ b/src-admin/src/i18n/ru.json
@@ -275,5 +275,11 @@
     "primary": "основной",
     "secondary": "резервный",
     "External Router": "Внешний маршрутизатор",
-    "External Device": "Внешнее устройство"
+    "External Device": "Внешнее устройство",
+    "Bidirectional LQI": "Двунаправленный LQI",
+    "Path Cost": "Стоимость маршрута",
+    "Route table only": "Только таблица маршрутизации",
+    "Connected devices": "Подключённые устройства",
+    "Signal: Unknown": "Сигнал: неизвестно",
+    "stale": "устарело"
 }

--- a/src-admin/src/i18n/ru.json
+++ b/src-admin/src/i18n/ru.json
@@ -252,5 +252,15 @@
     "status_disconnected": "Отключено",
     "status_waitingForCommissioning": "Ожидание ввода в эксплуатацию",
     "status_waitingForDeviceDiscovery": "Ожидание обнаружения устройства",
-    "to bridge": "преодолеть"
+    "to bridge": "преодолеть",
+    "BSSID": "BSSID",
+    "Border Router": "Пограничный маршрутизатор",
+    "Click a node to see details": "Нажмите на узел для просмотра деталей",
+    "Filter": "Фильтр",
+    "Hide medium links": "Скрыть средние соединения",
+    "Hide offline nodes": "Скрыть офлайн-узлы",
+    "Hide strong links": "Скрыть сильные соединения",
+    "Hide weak links": "Скрыть слабые соединения",
+    "Search mesh": "Поиск в сети",
+    "Thread Version": "Версия Thread"
 }

--- a/src-admin/src/i18n/uk.json
+++ b/src-admin/src/i18n/uk.json
@@ -262,5 +262,18 @@
     "Hide strong links": "Сховати сильні зʼєднання",
     "Hide weak links": "Сховати слабкі зʼєднання",
     "Search mesh": "Пошук у мережі",
-    "Thread Version": "Версія Thread"
+    "Thread Version": "Версія Thread",
+    "Network": "Мережа",
+    "Vendor": "Виробник",
+    "Model": "Модель",
+    "Partition": "Розділ",
+    "Addresses": "Адреси",
+    "Seen by": "Бачать вузли",
+    "Border Agent": "Border Agent",
+    "Detached": "Відключено",
+    "Child": "Дочірній",
+    "primary": "основний",
+    "secondary": "резервний",
+    "External Router": "Зовнішній маршрутизатор",
+    "External Device": "Зовнішній пристрій"
 }

--- a/src-admin/src/i18n/uk.json
+++ b/src-admin/src/i18n/uk.json
@@ -275,5 +275,11 @@
     "primary": "основний",
     "secondary": "резервний",
     "External Router": "Зовнішній маршрутизатор",
-    "External Device": "Зовнішній пристрій"
+    "External Device": "Зовнішній пристрій",
+    "Bidirectional LQI": "Двонаправлений LQI",
+    "Path Cost": "Вартість маршруту",
+    "Route table only": "Лише таблиця маршрутизації",
+    "Connected devices": "Підключені пристрої",
+    "Signal: Unknown": "Сигнал: невідомо",
+    "stale": "застаріло"
 }

--- a/src-admin/src/i18n/uk.json
+++ b/src-admin/src/i18n/uk.json
@@ -252,5 +252,15 @@
     "status_disconnected": "Відключено",
     "status_waitingForCommissioning": "Очікування здачі в експлуатацію",
     "status_waitingForDeviceDiscovery": "Очікування виявлення пристрою",
-    "to bridge": "мостити"
+    "to bridge": "мостити",
+    "BSSID": "BSSID",
+    "Border Router": "Прикордонний маршрутизатор",
+    "Click a node to see details": "Натисніть вузол, щоб побачити деталі",
+    "Filter": "Фільтр",
+    "Hide medium links": "Сховати середні зʼєднання",
+    "Hide offline nodes": "Сховати офлайн-вузли",
+    "Hide strong links": "Сховати сильні зʼєднання",
+    "Hide weak links": "Сховати слабкі зʼєднання",
+    "Search mesh": "Пошук у мережі",
+    "Thread Version": "Версія Thread"
 }

--- a/src-admin/src/i18n/zh-cn.json
+++ b/src-admin/src/i18n/zh-cn.json
@@ -262,5 +262,18 @@
     "Hide strong links": "隐藏强连接",
     "Hide weak links": "隐藏弱连接",
     "Search mesh": "搜索网格",
-    "Thread Version": "Thread 版本"
+    "Thread Version": "Thread 版本",
+    "Network": "网络",
+    "Vendor": "厂商",
+    "Model": "型号",
+    "Partition": "分区",
+    "Addresses": "地址",
+    "Seen by": "可见于",
+    "Border Agent": "边界代理",
+    "Detached": "已分离",
+    "Child": "子节点",
+    "primary": "主",
+    "secondary": "备",
+    "External Router": "外部路由器",
+    "External Device": "外部设备"
 }

--- a/src-admin/src/i18n/zh-cn.json
+++ b/src-admin/src/i18n/zh-cn.json
@@ -252,5 +252,15 @@
     "status_disconnected": "已断开连接",
     "status_waitingForCommissioning": "等待调试",
     "status_waitingForDeviceDiscovery": "等待设备发现",
-    "to bridge": "桥接"
+    "to bridge": "桥接",
+    "BSSID": "BSSID",
+    "Border Router": "边界路由器",
+    "Click a node to see details": "点击节点查看详情",
+    "Filter": "筛选",
+    "Hide medium links": "隐藏中等连接",
+    "Hide offline nodes": "隐藏离线节点",
+    "Hide strong links": "隐藏强连接",
+    "Hide weak links": "隐藏弱连接",
+    "Search mesh": "搜索网格",
+    "Thread Version": "Thread 版本"
 }

--- a/src-admin/src/i18n/zh-cn.json
+++ b/src-admin/src/i18n/zh-cn.json
@@ -275,5 +275,11 @@
     "primary": "主",
     "secondary": "备",
     "External Router": "外部路由器",
-    "External Device": "外部设备"
+    "External Device": "外部设备",
+    "Bidirectional LQI": "双向 LQI",
+    "Path Cost": "路径开销",
+    "Route table only": "仅路由表",
+    "Connected devices": "已连接设备",
+    "Signal: Unknown": "信号：未知",
+    "stale": "已过期"
 }

--- a/src-admin/src/types.d.ts
+++ b/src-admin/src/types.d.ts
@@ -227,6 +227,8 @@ export interface NetworkNodeData {
     name: string;
     vendorId?: string;
     productId?: string;
+    /** Primary application Matter device-type id (for icon selection). */
+    deviceType?: number;
     isConnected: boolean;
     networkType: NetworkType;
     wifi?: WiFiDiagnosticsData;
@@ -247,6 +249,8 @@ export interface ThreadDiagnosticsData {
     extendedPanId: string | null;
     rloc16: number | null;
     extendedAddress: string | null;
+    /** Thread spec version (NetworkCommissioning ThreadVersion attr); e.g. 4 = Thread 1.3. */
+    threadVersion: number | null;
     neighborTable: ThreadNeighborEntry[];
     routeTable: ThreadRouteEntry[];
 }
@@ -277,4 +281,52 @@ export interface ThreadRouteEntry {
     age: number;
     allocated: boolean;
     linkEstablished: boolean;
+}
+
+/**
+ * Single Thread Border Router record discovered via mDNS.
+ *
+ * The extended address (xa) is the 64-bit Thread MAC of the border agent and serves as
+ * the primary key. It is the same value as ThreadNetworkDiagnostics.NeighborTable.extAddress
+ * for a BR that is itself a Thread router, which is what allows the graph to join
+ * BRs onto external-device entries seen in commissioned-node neighbor tables.
+ */
+export interface BorderRouterEntry {
+    /** 16-char uppercase hex of the 64-bit Thread MAC. Primary key. */
+    extAddressHex: string;
+    /** 16-char uppercase hex of the extended PAN ID, when known. */
+    extendedPanIdHex?: string;
+    /** Friendly Thread network name (`_meshcop` TXT "nn"). */
+    networkName?: string;
+    /** Vendor name (`_meshcop` TXT "vn"). */
+    vendorName?: string;
+    /** Model name (`_meshcop` TXT "mn"). */
+    modelName?: string;
+    /** mDNS hostname from the SRV target, e.g. "Kuche.local.". */
+    hostname?: string;
+    /** Sorted IPv4 + IPv6 addresses resolved from the SRV target's A/AAAA records. */
+    addresses: string[];
+    /** Service port from the `_meshcop` SRV record. */
+    meshcopPort?: number;
+    /** Service port from the `_trel` SRV record. */
+    trelPort?: number;
+    /** Thread version, e.g. "1.3.0" (`_meshcop` TXT "tv"). */
+    threadVersion?: string;
+    /** Border agent ID hex (`_meshcop` TXT "dd"); not always present. */
+    borderAgentIdHex?: string;
+    /** Raw 4-byte state bitmap as hex (`_meshcop` TXT "sb"). Flag parsing left to frontend. */
+    stateBitmapHex?: string;
+    /** Active timestamp as hex (`_meshcop` TXT "at"). */
+    activeTimestampHex?: string;
+    /** Partition ID as hex (`_meshcop` TXT "pt"). */
+    partitionIdHex?: string;
+    /** Vendor-specific data domain name (`_meshcop` TXT "dn"). */
+    domainName?: string;
+    /** Which mDNS source(s) contributed to this entry. */
+    sources: ('meshcop' | 'trel')[];
+    /**
+     * Epoch milliseconds of the most recent successful mDNS discovery for this entry.
+     * `sources.length === 0` means stale; stale age is `Date.now() - lastSeen`.
+     */
+    lastSeen: number;
 }

--- a/src-admin/tsconfig.json
+++ b/src-admin/tsconfig.json
@@ -3,7 +3,7 @@
 {
     "compilerOptions": {
         "module": "esnext",
-        "moduleResolution": "node",
+        "moduleResolution": "bundler",
         // check JS files
         "allowJs": true,
         // This is necessary for the automatic typing of the adapter config
@@ -18,7 +18,6 @@
         // "noUnusedParameters": true,
         "useUnknownInCatchVariables": false,
         "target": "ES2022",
-        "baseUrl": "./",
         "allowSyntheticDefaultImports": true,
         "checkJs": false,
         "noEmit": false,

--- a/src/ioBrokerTypes.ts
+++ b/src/ioBrokerTypes.ts
@@ -62,6 +62,8 @@ export interface NetworkNodeData {
     name: string;
     vendorId?: string;
     productId?: string;
+    /** Primary application Matter device-type id (for icon selection). */
+    deviceType?: number;
     isConnected: boolean;
     networkType: NetworkType;
     wifi?: WiFiDiagnosticsData;
@@ -82,6 +84,8 @@ export interface ThreadDiagnosticsData {
     extendedPanId: string | null;
     rloc16: number | null;
     extendedAddress: string | null;
+    /** Thread spec version (NetworkCommissioning ThreadVersion attr); e.g. 4 = Thread 1.3. */
+    threadVersion: number | null;
     neighborTable: ThreadNeighborEntry[];
     routeTable: ThreadRouteEntry[];
 }
@@ -112,4 +116,57 @@ export interface ThreadRouteEntry {
     age: number;
     allocated: boolean;
     linkEstablished: boolean;
+}
+
+/**
+ * Single Thread Border Router record discovered via mDNS.
+ *
+ * The extended address (xa) is the 64-bit Thread MAC of the border agent and serves as
+ * the primary key. It is the same value as ThreadNetworkDiagnostics.NeighborTable.extAddress
+ * for a BR that is itself a Thread router, which is what allows the graph to join
+ * BRs onto external-device entries seen in commissioned-node neighbor tables.
+ */
+export interface BorderRouterEntry {
+    /** 16-char uppercase hex of the 64-bit Thread MAC. Primary key. */
+    extAddressHex: string;
+    /** 16-char uppercase hex of the extended PAN ID, when known. */
+    extendedPanIdHex?: string;
+    /** Friendly Thread network name (`_meshcop` TXT "nn"). */
+    networkName?: string;
+    /** Vendor name (`_meshcop` TXT "vn"). */
+    vendorName?: string;
+    /** Model name (`_meshcop` TXT "mn"). */
+    modelName?: string;
+    /** mDNS hostname from the SRV target, e.g. "Kuche.local.". */
+    hostname?: string;
+    /** Sorted IPv4 + IPv6 addresses resolved from the SRV target's A/AAAA records. */
+    addresses: string[];
+    /** Service port from the `_meshcop` SRV record. */
+    meshcopPort?: number;
+    /** Service port from the `_trel` SRV record. */
+    trelPort?: number;
+    /** Thread version, e.g. "1.3.0" (`_meshcop` TXT "tv"). */
+    threadVersion?: string;
+    /** Border agent ID hex (`_meshcop` TXT "dd"); not always present. */
+    borderAgentIdHex?: string;
+    /** Raw 4-byte state bitmap as hex (`_meshcop` TXT "sb"). Flag parsing left to frontend. */
+    stateBitmapHex?: string;
+    /** Active timestamp as hex (`_meshcop` TXT "at"). */
+    activeTimestampHex?: string;
+    /** Partition ID as hex (`_meshcop` TXT "pt"). */
+    partitionIdHex?: string;
+    /** Vendor-specific data domain name (`_meshcop` TXT "dn"). */
+    domainName?: string;
+    /** Which mDNS source(s) contributed to this entry. */
+    sources: ('meshcop' | 'trel')[];
+    /**
+     * Epoch milliseconds of the most recent successful mDNS discovery for this entry.
+     * Frozen when `sources` becomes empty (the entry is "stale"); updated on every
+     * re-discovery. Stale entries are retained for at least 24h after `lastSeen`; the
+     * actual prune is lazy and happens on the next `get`, `list`, or mDNS discovery
+     * event after the window elapses, so an entry may linger longer than 24h if there
+     * is no activity. Consumers can derive stale state via `sources.length === 0` and
+     * stale age via `Date.now() - lastSeen`.
+     */
+    lastSeen: number;
 }

--- a/src/lib/devices/GenericDevice.ts
+++ b/src/lib/devices/GenericDevice.ts
@@ -1,7 +1,7 @@
 // @iobroker/device-types
 
 import type { DetectorState, Types, StateType } from '@iobroker/type-detector';
-import type { BridgeDeviceDescription } from '../../ioBrokerStorageTypes';
+import type { BridgeDeviceDescription } from '../../ioBrokerTypes';
 import type { CustomStateCommon, CustomStatesRecord } from '../../matter/to-iobroker/custom-states';
 import { DeviceStateObject, PropertyType, ValueType } from './DeviceStateObject';
 import { EventEmitter } from 'events';

--- a/src/main.ts
+++ b/src/main.ts
@@ -29,7 +29,7 @@ import type {
     DeviceDescription,
     MatterAdapterConfig,
     MatterControllerConfig,
-} from './ioBrokerStorageTypes';
+} from './ioBrokerTypes';
 import { DeviceFactory, type GenericDevice, SubscribeManager } from './lib';
 import MatterAdapterDeviceManagement from './lib/DeviceManagement';
 import type { DetectedDevice } from './lib/devices/GenericDevice';

--- a/src/matter/BorderRouterDiscovery.ts
+++ b/src/matter/BorderRouterDiscovery.ts
@@ -1,0 +1,682 @@
+import { Bytes, type DnsRecord, DnsRecordType, type Environment, Logger, type SrvRecordValue } from '@matter/main';
+import { MdnsService } from '@matter/main/protocol';
+import type { BorderRouterEntry } from '../ioBrokerTypes';
+
+const logger = Logger.get('BorderRouterDiscovery');
+
+const REGISTRY_MAX_ENTRIES = 256;
+/**
+ * Generous headroom above REGISTRY_MAX_ENTRIES so we still observe instances that haven't
+ * yet emitted a valid xa, but bounded so a noisy LAN can't grow `#instanceObservers`
+ * without limit. Eviction targets the oldest xa-less observer first.
+ */
+const INSTANCE_OBSERVER_CAP = 512;
+/**
+ * Stale entries (sources.length === 0) become eligible for pruning 24h after their
+ * last successful mDNS discovery (entry.lastSeen). Pruning is lazy — `#pruneExpired`
+ * runs on `list` / `get` / `#onDiscovered`, so without activity an eligible entry
+ * may linger past the window. Long enough that BRs announcing once per ~half-day
+ * stay resolvable; short enough that vanished BRs eventually drop.
+ */
+const STALE_RETENTION_MS = 24 * 60 * 60 * 1000;
+const MESHCOP_TYPE_QNAME = '_meshcop._udp.local';
+const TREL_TYPE_QNAME = '_trel._udp.local';
+const MESHCOP_SUFFIX = '._meshcop._udp.local';
+const TREL_SUFFIX = '._trel._udp.local';
+
+type Source = 'meshcop' | 'trel';
+
+interface DnssdRecordLike {
+    recordType: DnsRecordType;
+    name: string;
+    value: unknown;
+}
+
+interface DnssdParametersLike extends ReadonlyMap<string, string> {
+    raw(key: string): Bytes | undefined;
+}
+
+interface DnssdNameLike {
+    readonly qname: string;
+    readonly parameters: DnssdParametersLike;
+    readonly records: Iterable<DnssdRecordLike>;
+    readonly isDiscovered: boolean;
+    on(observer: NameObserver): void;
+    off(observer: NameObserver): void;
+}
+
+interface DnssdNamesFiltersLike {
+    add(filter: (record: DnsRecord) => boolean): unknown;
+    delete(filter: (record: DnsRecord) => boolean): unknown;
+}
+
+interface DiscoveredObservableLike {
+    on(observer: DiscoveredObserver): void;
+    off(observer: DiscoveredObserver): void;
+}
+
+interface SolicitorLike {
+    solicit(solicitation: { name: DnssdNameLike; recordTypes: DnsRecordType[] }): void;
+}
+
+interface DnssdNamesLike {
+    readonly filters: DnssdNamesFiltersLike;
+    readonly discovered: DiscoveredObservableLike;
+    readonly solicitor: SolicitorLike;
+    get(qname: string): DnssdNameLike;
+    maybeGet(qname: string): DnssdNameLike | undefined;
+}
+
+type DiscoveredObserver = (name: DnssdNameLike) => void;
+type NameObserver = (changes: { name: DnssdNameLike; updated?: unknown[]; deleted?: unknown[] }) => void;
+
+interface InstanceTracking {
+    name: DnssdNameLike;
+    source: Source;
+    observer: NameObserver;
+    targetKey?: string;
+    xaKey?: string;
+    /**
+     * Set when the observer is attached. Used to evict oldest xa-less observers when
+     * `#instanceObservers` grows past {@link INSTANCE_OBSERVER_CAP}.
+     */
+    firstSeen: number;
+}
+
+interface TargetTracking {
+    target: DnssdNameLike;
+    observer: NameObserver;
+    refcount: number;
+}
+
+/**
+ * Passive Thread Border Router discovery via mDNS.
+ *
+ * Subscribes to `_meshcop._udp.local` and `_trel._udp.local`, builds a per-extended-address
+ * registry, and exposes the current entries through {@link list}. Owned by the controller node.
+ */
+export class BorderRouterDiscovery {
+    readonly #env: Environment;
+    readonly #registry = new Map<string, BorderRouterEntry>();
+    readonly #instanceObservers = new Map<string, InstanceTracking>();
+    readonly #targetObservers = new Map<string, TargetTracking>();
+    #names?: DnssdNamesLike;
+    #injectedNames?: DnssdNamesLike;
+    #suffixFilter?: (record: DnsRecord) => boolean;
+    #discoveredObserver?: DiscoveredObserver;
+    #started = false;
+    /**
+     * Incremented on every start/stop. Lets a pending `await mdns.construction.ready`
+     * detect that `stop()` ran while it was suspended and abort partial setup.
+     */
+    #startGeneration = 0;
+    #evictionWarnedThisCycle = false;
+
+    constructor(env: Environment, names?: DnssdNamesLike) {
+        this.#env = env;
+        this.#injectedNames = names;
+    }
+
+    async start(): Promise<void> {
+        if (this.#started) {
+            return;
+        }
+        const gen = ++this.#startGeneration;
+        this.#evictionWarnedThisCycle = false;
+
+        let names: DnssdNamesLike;
+        if (this.#injectedNames !== undefined) {
+            names = this.#injectedNames;
+        } else {
+            try {
+                const mdns = this.#env.get(MdnsService);
+                await mdns.construction.ready;
+                if (gen !== this.#startGeneration) {
+                    return;
+                }
+                names = mdns.names;
+            } catch (e) {
+                if (gen !== this.#startGeneration) {
+                    return;
+                }
+                logger.error('MDNS service unavailable; border router discovery inactive:', e);
+                return;
+            }
+        }
+        this.#started = true;
+        this.#names = names;
+
+        const suffixFilter = ({ name }: DnsRecord): boolean => {
+            const lower = name.toLowerCase();
+            return lower.endsWith(MESHCOP_SUFFIX) || lower.endsWith(TREL_SUFFIX);
+        };
+        this.#suffixFilter = suffixFilter;
+        names.filters.add(suffixFilter);
+
+        const meshcopType = names.get(MESHCOP_TYPE_QNAME);
+        const trelType = names.get(TREL_TYPE_QNAME);
+        names.solicitor.solicit({ name: meshcopType, recordTypes: [DnsRecordType.PTR] });
+        names.solicitor.solicit({ name: trelType, recordTypes: [DnsRecordType.PTR] });
+
+        const observer: DiscoveredObserver = name => this.#onDiscovered(name);
+        this.#discoveredObserver = observer;
+        names.discovered.on(observer);
+    }
+
+    stop(): void {
+        // Bump the generation so any in-flight start() exits without attaching observers.
+        this.#startGeneration++;
+        if (!this.#started) {
+            return;
+        }
+        this.#started = false;
+
+        const names = this.#names;
+        if (names !== undefined) {
+            if (this.#discoveredObserver !== undefined) {
+                names.discovered.off(this.#discoveredObserver);
+            }
+            if (this.#suffixFilter !== undefined) {
+                names.filters.delete(this.#suffixFilter);
+            }
+        }
+        this.#discoveredObserver = undefined;
+        this.#suffixFilter = undefined;
+
+        for (const tracking of this.#instanceObservers.values()) {
+            tracking.name.off(tracking.observer);
+        }
+        this.#instanceObservers.clear();
+
+        for (const tracking of this.#targetObservers.values()) {
+            tracking.target.off(tracking.observer);
+        }
+        this.#targetObservers.clear();
+
+        this.#registry.clear();
+        this.#names = undefined;
+    }
+
+    list(): BorderRouterEntry[] {
+        this.#pruneExpired();
+        return Array.from(this.#registry.values(), entry => this.#snapshotEntry(entry));
+    }
+
+    get(extAddressHex: string): BorderRouterEntry | undefined {
+        this.#pruneExpired();
+        const entry = this.#registry.get(extAddressHex.toUpperCase());
+        return entry === undefined ? undefined : this.#snapshotEntry(entry);
+    }
+
+    #pruneExpired(): void {
+        const cutoff = Date.now() - STALE_RETENTION_MS;
+        for (const [xaKey, entry] of this.#registry) {
+            if (entry.sources.length === 0 && entry.lastSeen < cutoff) {
+                this.#registry.delete(xaKey);
+            }
+        }
+    }
+
+    /** Shallow copy so callers cannot mutate registry state through the returned reference. */
+    #snapshotEntry(entry: BorderRouterEntry): BorderRouterEntry {
+        return {
+            ...entry,
+            sources: [...entry.sources],
+            addresses: [...entry.addresses],
+        };
+    }
+
+    #onDiscovered(name: DnssdNameLike): void {
+        if (!this.#started) {
+            return;
+        }
+        this.#pruneExpired();
+        const lower = name.qname.toLowerCase();
+        if (lower === MESHCOP_TYPE_QNAME || lower === TREL_TYPE_QNAME) {
+            return;
+        }
+        let source: Source;
+        if (lower.endsWith(MESHCOP_SUFFIX)) {
+            source = 'meshcop';
+        } else if (lower.endsWith(TREL_SUFFIX)) {
+            source = 'trel';
+        } else {
+            return;
+        }
+
+        const key = lower;
+        if (this.#instanceObservers.has(key)) {
+            return;
+        }
+
+        if (this.#instanceObservers.size >= INSTANCE_OBSERVER_CAP) {
+            // Drop xa-less observers first (cheapest to lose); if every observer already
+            // has an xa, fall back to evicting the oldest registry entry, which detaches
+            // its instance observers via the same path. Repeat until under the cap so
+            // the cap is strictly enforced even on a flood of valid-xa instances.
+            while (this.#instanceObservers.size >= INSTANCE_OBSERVER_CAP) {
+                if (!this.#evictOldestPendingInstance() && !this.#evictOldest()) {
+                    break;
+                }
+            }
+        }
+
+        const observer: NameObserver = () => this.#onInstanceChanged(name, source);
+        this.#instanceObservers.set(key, { name, source, observer, firstSeen: Date.now() });
+        name.on(observer);
+
+        this.#parseAndUpsert(name, source);
+    }
+
+    /**
+     * Evict the oldest xa-less instance observer when the observer cap is hit. Instances
+     * that never publish a valid `xa` (malformed broadcasters or hostile noise) would
+     * otherwise pin observers in `#instanceObservers` indefinitely — eviction targets only
+     * those because observers tied to real registry entries are managed by `#evictOldest`.
+     */
+    #evictOldestPendingInstance(): boolean {
+        let oldestKey: string | undefined;
+        let oldestSeen = Number.POSITIVE_INFINITY;
+        for (const [k, t] of this.#instanceObservers) {
+            if (t.xaKey !== undefined) {
+                continue;
+            }
+            if (t.firstSeen < oldestSeen) {
+                oldestSeen = t.firstSeen;
+                oldestKey = k;
+            }
+        }
+        if (oldestKey === undefined) {
+            return false;
+        }
+        const tracking = this.#instanceObservers.get(oldestKey);
+        if (tracking === undefined) {
+            return false;
+        }
+        tracking.name.off(tracking.observer);
+        if (tracking.targetKey !== undefined) {
+            this.#releaseTarget(tracking.targetKey);
+        }
+        this.#instanceObservers.delete(oldestKey);
+        return true;
+    }
+
+    #onInstanceChanged(name: DnssdNameLike, source: Source): void {
+        if (!this.#started) {
+            return;
+        }
+        if (name.isDiscovered) {
+            try {
+                this.#parseAndUpsert(name, source);
+            } catch (e) {
+                logger.debug('Error processing border router instance change:', e);
+            }
+            return;
+        }
+
+        const key = name.qname.toLowerCase();
+        const tracking = this.#instanceObservers.get(key);
+        if (tracking === undefined) {
+            return;
+        }
+        tracking.name.off(tracking.observer);
+        this.#instanceObservers.delete(key);
+
+        if (tracking.targetKey !== undefined) {
+            this.#releaseTarget(tracking.targetKey);
+        }
+
+        const xaKey = tracking.xaKey;
+        if (xaKey === undefined) {
+            return;
+        }
+        const entry = this.#registry.get(xaKey);
+        if (entry === undefined) {
+            return;
+        }
+        const idx = entry.sources.indexOf(source);
+        if (idx !== -1) {
+            entry.sources.splice(idx, 1);
+        }
+    }
+
+    #onTargetChanged(target: DnssdNameLike): void {
+        if (!this.#started) {
+            return;
+        }
+        try {
+            const targetQname = target.qname.toLowerCase();
+            for (const entry of this.#registry.values()) {
+                if (entry.hostname?.toLowerCase() === targetQname) {
+                    entry.addresses = this.#sortAddresses(this.#collectAddresses(target));
+                }
+            }
+        } catch (e) {
+            logger.debug('Error processing border router target change:', e);
+        }
+    }
+
+    #parseAndUpsert(name: DnssdNameLike, source: Source): void {
+        const names = this.#names;
+        if (names === undefined) {
+            return;
+        }
+
+        try {
+            const params = name.parameters;
+            const xaKey = rawHex(params.raw('xa'), 8);
+            if (xaKey === undefined) {
+                return;
+            }
+
+            const records = Array.from(name.records);
+            const srvRecord = records.find(r => r.recordType === DnsRecordType.SRV);
+            let srvTarget: string | undefined;
+            let srvPort: number | undefined;
+            if (srvRecord !== undefined && isSrvValue(srvRecord.value)) {
+                srvTarget = srvRecord.value.target;
+                srvPort = srvRecord.value.port;
+            }
+
+            let addresses: string[] = [];
+            const tracking = this.#instanceObservers.get(name.qname.toLowerCase());
+            if (srvTarget !== undefined) {
+                const target = names.get(srvTarget);
+                addresses = this.#sortAddresses(this.#collectAddresses(target));
+                this.#attachTargetObserver(name, srvTarget, target);
+            } else if (tracking?.targetKey !== undefined) {
+                // Update dropped the SRV record. Release the previously-attached target
+                // observer so its refcount is decremented and the entry doesn't keep
+                // receiving address updates for a hostname this instance no longer points at.
+                this.#releaseTarget(tracking.targetKey);
+                tracking.targetKey = undefined;
+            }
+
+            const xp = rawHex(params.raw('xp'), 8);
+
+            const existing = this.#registry.get(xaKey);
+            const meshcopWins = source === 'meshcop';
+            const entry: BorderRouterEntry = existing ?? {
+                extAddressHex: xaKey,
+                addresses: [],
+                sources: [],
+                lastSeen: Date.now(),
+            };
+
+            const meshcopAlreadyContributed = entry.sources.includes('meshcop');
+            const canOverwrite = meshcopWins || !meshcopAlreadyContributed;
+
+            if (xp !== undefined && canOverwrite) {
+                entry.extendedPanIdHex = xp;
+            }
+
+            const previousHostname = entry.hostname;
+            if (srvTarget !== undefined && canOverwrite) {
+                entry.hostname = srvTarget;
+            }
+
+            if (
+                source === 'meshcop' &&
+                srvTarget !== undefined &&
+                previousHostname !== undefined &&
+                previousHostname.toLowerCase() !== srvTarget.toLowerCase()
+            ) {
+                this.#repointTrelTargetForXa(xaKey, previousHostname, srvTarget, names);
+            }
+
+            if (addresses.length > 0 && canOverwrite) {
+                entry.addresses = addresses;
+            }
+
+            if (source === 'meshcop') {
+                if (srvPort !== undefined) {
+                    entry.meshcopPort = srvPort;
+                }
+                const nn = params.get('nn');
+                if (nn !== undefined) {
+                    entry.networkName = nn;
+                }
+                const vn = params.get('vn');
+                if (vn !== undefined) {
+                    entry.vendorName = vn;
+                }
+                const mn = params.get('mn');
+                if (mn !== undefined) {
+                    entry.modelName = mn;
+                }
+                const tv = params.get('tv');
+                if (tv !== undefined) {
+                    entry.threadVersion = tv;
+                }
+                // dd (border-agent ID) is variable-width per spec; xa/xp/at = 8 bytes,
+                // pt/sb = 4 bytes (Thread MeshCoP). Reject malformed lengths for fixed
+                // fields so a malformed broadcaster can't pollute the snapshot.
+                const dd = rawHex(params.raw('dd'));
+                if (dd !== undefined) {
+                    entry.borderAgentIdHex = dd;
+                }
+                const sb = rawHex(params.raw('sb'), 4);
+                if (sb !== undefined) {
+                    entry.stateBitmapHex = sb;
+                }
+                const at = rawHex(params.raw('at'), 8);
+                if (at !== undefined) {
+                    entry.activeTimestampHex = at;
+                }
+                const pt = rawHex(params.raw('pt'), 4);
+                if (pt !== undefined) {
+                    entry.partitionIdHex = pt;
+                }
+                const dn = params.get('dn');
+                if (dn !== undefined) {
+                    entry.domainName = dn;
+                }
+            } else if (source === 'trel') {
+                if (srvPort !== undefined) {
+                    entry.trelPort = srvPort;
+                }
+            }
+
+            if (!entry.sources.includes(source)) {
+                if (source === 'meshcop') {
+                    entry.sources.unshift(source);
+                } else {
+                    entry.sources.push(source);
+                }
+            }
+            entry.lastSeen = Date.now();
+
+            if (existing === undefined) {
+                if (this.#registry.size >= REGISTRY_MAX_ENTRIES) {
+                    this.#evictOldest();
+                }
+                this.#registry.set(xaKey, entry);
+            }
+
+            if (tracking !== undefined) {
+                tracking.xaKey = xaKey;
+            }
+        } catch (e) {
+            logger.debug('Error parsing border router record:', e);
+        }
+    }
+
+    #collectAddresses(target: DnssdNameLike): string[] {
+        const out = new Array<string>();
+        for (const record of target.records) {
+            if (record.recordType !== DnsRecordType.A && record.recordType !== DnsRecordType.AAAA) {
+                continue;
+            }
+            if (typeof record.value === 'string') {
+                out.push(record.value);
+            }
+        }
+        return out;
+    }
+
+    #sortAddresses(addresses: string[]): string[] {
+        const seen = new Set<string>();
+        const unique = new Array<string>();
+        for (const addr of addresses) {
+            if (!seen.has(addr)) {
+                seen.add(addr);
+                unique.push(addr);
+            }
+        }
+        const ipv4 = unique.filter(a => !a.includes(':'));
+        const ipv6 = unique.filter(a => a.includes(':'));
+        const categorize = (a: string): number => {
+            const lower = a.toLowerCase();
+            if (lower.startsWith('fe80:')) {
+                return 2;
+            }
+            if (lower.startsWith('fc') || lower.startsWith('fd')) {
+                return 1;
+            }
+            const firstChar = lower.charAt(0);
+            if (firstChar === '2' || firstChar === '3') {
+                return 0;
+            }
+            return 3;
+        };
+        ipv6.sort((a, b) => {
+            const ca = categorize(a);
+            const cb = categorize(b);
+            if (ca !== cb) {
+                return ca - cb;
+            }
+            return a.localeCompare(b);
+        });
+        ipv4.sort((a, b) => a.localeCompare(b));
+        return [...ipv4, ...ipv6];
+    }
+
+    #attachTargetObserver(instance: DnssdNameLike, srvTarget: string, target: DnssdNameLike): void {
+        const targetKey = srvTarget.toLowerCase();
+        const instanceKey = instance.qname.toLowerCase();
+        const instanceTracking = this.#instanceObservers.get(instanceKey);
+        const previousTargetKey = instanceTracking?.targetKey;
+
+        if (previousTargetKey === targetKey) {
+            return;
+        }
+
+        if (previousTargetKey !== undefined) {
+            this.#releaseTarget(previousTargetKey);
+        }
+
+        const existing = this.#targetObservers.get(targetKey);
+        if (existing !== undefined) {
+            existing.refcount++;
+        } else {
+            const observer: NameObserver = () => this.#onTargetChanged(target);
+            target.on(observer);
+            this.#targetObservers.set(targetKey, { target, observer, refcount: 1 });
+        }
+        if (instanceTracking !== undefined) {
+            instanceTracking.targetKey = targetKey;
+        }
+    }
+
+    #repointTrelTargetForXa(xaKey: string, previousHostname: string, newTarget: string, names: DnssdNamesLike): void {
+        const previousKey = previousHostname.toLowerCase();
+        for (const tracking of this.#instanceObservers.values()) {
+            if (tracking.xaKey !== xaKey) {
+                continue;
+            }
+            if (tracking.source !== 'trel') {
+                continue;
+            }
+            if (tracking.targetKey !== previousKey) {
+                continue;
+            }
+            this.#attachTargetObserver(tracking.name, newTarget, names.get(newTarget));
+        }
+    }
+
+    #releaseTarget(targetKey: string): void {
+        const tracking = this.#targetObservers.get(targetKey);
+        if (tracking === undefined) {
+            return;
+        }
+        tracking.refcount--;
+        if (tracking.refcount <= 0) {
+            tracking.target.off(tracking.observer);
+            this.#targetObservers.delete(targetKey);
+        }
+    }
+
+    #evictOldest(): boolean {
+        let oldestStaleKey: string | undefined;
+        let oldestStaleSeen = Number.POSITIVE_INFINITY;
+        let oldestLiveKey: string | undefined;
+        let oldestLiveSeen = Number.POSITIVE_INFINITY;
+        for (const [xa, entry] of this.#registry) {
+            if (entry.sources.length === 0) {
+                if (entry.lastSeen < oldestStaleSeen) {
+                    oldestStaleSeen = entry.lastSeen;
+                    oldestStaleKey = xa;
+                }
+            } else if (entry.lastSeen < oldestLiveSeen) {
+                oldestLiveSeen = entry.lastSeen;
+                oldestLiveKey = xa;
+            }
+        }
+        const evictKey = oldestStaleKey ?? oldestLiveKey;
+        if (evictKey === undefined) {
+            return false;
+        }
+
+        this.#registry.delete(evictKey);
+
+        let releasedObservers = 0;
+        for (const [instanceKey, tracking] of [...this.#instanceObservers]) {
+            if (tracking.xaKey !== evictKey) {
+                continue;
+            }
+            tracking.name.off(tracking.observer);
+            if (tracking.targetKey !== undefined) {
+                this.#releaseTarget(tracking.targetKey);
+            }
+            this.#instanceObservers.delete(instanceKey);
+            releasedObservers++;
+        }
+
+        if (!this.#evictionWarnedThisCycle) {
+            this.#evictionWarnedThisCycle = true;
+            logger.warn(
+                `Border router registry exceeded ${REGISTRY_MAX_ENTRIES} entries; evicting oldest (released ${releasedObservers} instance observer${releasedObservers === 1 ? '' : 's'})`,
+            );
+        } else {
+            logger.debug(`Evicted border router xa=${evictKey}; released ${releasedObservers} instance observers`);
+        }
+        return true;
+    }
+}
+
+function isSrvValue(value: unknown): value is SrvRecordValue {
+    return (
+        typeof value === 'object' &&
+        value !== null &&
+        'target' in value &&
+        typeof value.target === 'string' &&
+        'port' in value &&
+        typeof value.port === 'number'
+    );
+}
+
+/**
+ * MeshCoP TXT records carry binary-valued fields (xa, xp, at, pt, dd, sb) — raw bytes per
+ * Thread spec. Bytes.toHex returns lowercase; callers can require an exact byte length so
+ * malformed broadcasters can't pollute the registry with non-canonical xa keys (the
+ * graph's xa→xa join expects uppercase 16-char hex, i.e. 8 bytes).
+ */
+function rawHex(bytes: Bytes | undefined, expectedByteLength?: number): string | undefined {
+    if (bytes === undefined || bytes.byteLength === 0) {
+        return undefined;
+    }
+    if (expectedByteLength !== undefined && bytes.byteLength !== expectedByteLength) {
+        return undefined;
+    }
+    return Bytes.toHex(bytes).toUpperCase();
+}

--- a/src/matter/BridgedDevicesNode.ts
+++ b/src/matter/BridgedDevicesNode.ts
@@ -3,7 +3,7 @@ import { BridgedDeviceBasicInformationServer, NetworkCommissioningServer } from 
 import { AggregatorEndpoint, BridgedNodeEndpoint } from '@matter/main/endpoints';
 import { NetworkCommissioning } from '@matter/main/clusters';
 import { inspect } from 'util';
-import type { BridgeDeviceDescription } from '../ioBrokerStorageTypes';
+import type { BridgeDeviceDescription } from '../ioBrokerTypes';
 import type { GenericDevice } from '../lib';
 import { md5, toUpperCaseHex } from '../lib/utils';
 import type { MatterAdapter } from '../main';

--- a/src/matter/ControllerNode.ts
+++ b/src/matter/ControllerNode.ts
@@ -3,6 +3,7 @@ import { ObserverGroup, SoftwareUpdateManager, Diagnostic, NodeId, VendorId, Sec
 import { GeneralCommissioning } from '@matter/main/clusters';
 import {
     GeneralDiagnosticsClient,
+    NetworkCommissioningClient,
     ThreadNetworkDiagnosticsClient,
     WiFiNetworkDiagnosticsClient,
 } from '@matter/main/behaviors';
@@ -26,8 +27,11 @@ import type {
     ThreadDiagnosticsData,
     ThreadNeighborEntry,
     ThreadRouteEntry,
-} from '../ioBrokerStorageTypes';
+    BorderRouterEntry,
+} from '../ioBrokerTypes';
+import { BorderRouterDiscovery } from './BorderRouterDiscovery';
 import { GeneralMatterNode, type PairedNodeConfig } from './GeneralMatterNode';
+import { identifyDeviceTypes } from './to-iobroker/ioBrokerFactory';
 import type { GeneralNode, MessageResponse } from './GeneralNode';
 import { inspect } from 'util';
 import { createReadStream } from 'fs';
@@ -51,7 +55,14 @@ interface AddDeviceResult {
 }
 
 // Re-export network types for external use
-export type { NetworkGraphData, NetworkNodeData, NetworkType, WiFiDiagnosticsData, ThreadDiagnosticsData };
+export type {
+    NetworkGraphData,
+    NetworkNodeData,
+    NetworkType,
+    WiFiDiagnosticsData,
+    ThreadDiagnosticsData,
+    BorderRouterEntry,
+};
 
 type EndUserCommissioningOptions = (
     | { qrCode: string }
@@ -72,6 +83,7 @@ class Controller implements GeneralNode {
     #observers = new ObserverGroup();
     #networkGraphUpdateTimer?: ioBroker.Timeout;
     #closing = false;
+    #borderRouterDiscovery?: BorderRouterDiscovery;
 
     constructor(options: ControllerCreateOptions) {
         const { adapter, controllerOptions, updateCallback, fabricLabel } = options;
@@ -249,6 +261,11 @@ class Controller implements GeneralNode {
                     await this.refreshNodeNetworkData(nodeIds);
                     return { result: 'ok' };
                 }
+                case 'controllerThreadBorderRouters': {
+                    // Return Thread border routers discovered via mDNS
+                    const borderRouters: BorderRouterEntry[] = this.#borderRouterDiscovery?.list() ?? [];
+                    return { result: borderRouters };
+                }
             }
         } catch (error) {
             const errorText = inspect(error, { depth: 10 });
@@ -372,6 +389,14 @@ class Controller implements GeneralNode {
             const errorText = inspect(error, { depth: 10 });
             this.#adapter.log.error(`Failed to start the controller: ${errorText}`);
             return;
+        }
+
+        this.#borderRouterDiscovery = new BorderRouterDiscovery(this.#adapter.matterEnvironment);
+        try {
+            await this.#borderRouterDiscovery.start();
+        } catch (error) {
+            // Border router discovery is non-critical; never let it abort controller startup
+            this.#adapter.log.warn(`Failed to start Thread border router discovery: ${error}`);
         }
 
         const nodesDetails = this.#commissioningController.getCommissionedNodesDetails();
@@ -902,11 +927,61 @@ class Controller implements GeneralNode {
             name: node.name,
             vendorId,
             productId,
+            deviceType: this.#getPrimaryDeviceType(node),
             isConnected: node.isConnected,
             networkType,
             wifi: wifiDiagnostics,
             thread: threadDiagnostics,
         };
+    }
+
+    /**
+     * Primary application Matter device-type id of a node, for icon selection. Prefers an
+     * application device type on any endpoint over utility types (Root/OTA/Power), which are
+     * commonly reported alongside the real device type.
+     */
+    #getPrimaryDeviceType(node: GeneralMatterNode): number | undefined {
+        const rootEndpoint = node.node.node;
+        if (rootEndpoint === undefined) {
+            return undefined;
+        }
+        // Infrastructure device types that should never drive the node icon. The Matter
+        // DeviceClassification reports Aggregator as a non-utility ("simple") app type, so
+        // it lands in appTypes and would otherwise mask the real bridged device behind it.
+        const INFRA_DEVICE_TYPES = new Set<number>([
+            0x000e, // Aggregator
+            0x0013, // Bridged Node
+            0x0011, // Power Source
+            0x0012, // OTA Requestor
+            0x0014, // OTA Provider
+            0x0016, // Root Node
+            0x0019, // Secondary Network Interface
+        ]);
+        // Children first so a real device endpoint wins over the root/aggregator endpoint.
+        const endpoints = new Array<Endpoint>();
+        const collect = (endpoint: Endpoint): void => {
+            for (const child of endpoint.parts) {
+                collect(child);
+            }
+            endpoints.push(endpoint);
+        };
+        try {
+            collect(rootEndpoint);
+            let fallback: number | undefined;
+            for (const endpoint of endpoints) {
+                const { appTypes, utilityTypes } = identifyDeviceTypes(endpoint);
+                const appType = appTypes.find(t => !INFRA_DEVICE_TYPES.has(t.deviceType.id));
+                if (appType !== undefined) {
+                    return appType.deviceType.id;
+                }
+                if (fallback === undefined) {
+                    fallback = appTypes[0]?.deviceType.id ?? utilityTypes[0]?.deviceType.id;
+                }
+            }
+            return fallback;
+        } catch {
+            return undefined;
+        }
     }
 
     #getNetworkType(node: GeneralMatterNode): NetworkType {
@@ -1005,12 +1080,21 @@ class Controller implements GeneralNode {
                 extendedPanId = this.#bigIntToBase64(extPanIdRaw);
             }
 
+            // Thread spec version from NetworkCommissioning (only present on Thread interfaces)
+            let threadVersion: number | null = null;
+            const netCommState = node.node.node.maybeStateOf(NetworkCommissioningClient);
+            if (netCommState !== undefined && 'threadVersion' in netCommState) {
+                const v = netCommState.threadVersion;
+                threadVersion = typeof v === 'number' ? v : null;
+            }
+
             return {
                 channel: threadState.channel ?? null,
                 routingRole: threadState.routingRole ?? null,
                 extendedPanId,
                 rloc16: threadState.rloc16 ?? null,
                 extendedAddress,
+                threadVersion,
                 neighborTable,
                 routeTable,
             };
@@ -1070,6 +1154,11 @@ class Controller implements GeneralNode {
         if (this.#networkGraphUpdateTimer) {
             this.#adapter.clearTimeout(this.#networkGraphUpdateTimer);
             this.#networkGraphUpdateTimer = undefined;
+        }
+
+        if (this.#borderRouterDiscovery) {
+            this.#borderRouterDiscovery.stop();
+            this.#borderRouterDiscovery = undefined;
         }
 
         for (const node of this.#nodes.values()) {

--- a/src/matter/DeviceNode.ts
+++ b/src/matter/DeviceNode.ts
@@ -2,7 +2,7 @@ import { ServerNode, VendorId } from '@matter/main';
 import { NetworkCommissioningServer } from '@matter/main/behaviors';
 import { NetworkCommissioning } from '@matter/main/clusters';
 import { inspect } from 'util';
-import type { DeviceDescription } from '../ioBrokerStorageTypes';
+import type { DeviceDescription } from '../ioBrokerTypes';
 import type { GenericDevice } from '../lib';
 import { md5, toUpperCaseHex } from '../lib/utils';
 import type { MatterAdapter } from '../main';

--- a/src/matter/GeneralMatterNode.ts
+++ b/src/matter/GeneralMatterNode.ts
@@ -36,7 +36,7 @@ import {
     type CommissioningControllerNodeOptions,
 } from '@project-chip/matter.js/device';
 import type { CommissioningController } from '@project-chip/matter.js';
-import type { MatterControllerConfig } from '../ioBrokerStorageTypes';
+import type { MatterControllerConfig } from '../ioBrokerTypes';
 import { SubscribeManager } from '../lib';
 import type { SubscribeCallback } from '../lib/SubscribeManager';
 import { bytesToIpV4, bytesToIpV6, bytesToMac, decamelize, toHex, toUpperCaseHex } from '../lib/utils';


### PR DESCRIPTION
Brings the Thread/WiFi network visualization to parity with the matter-js/matterjs-server dashboard.

## Highlights
- **OTBR mDNS discovery** (backend): passive `_meshcop`/`_trel` discovery with 24h stale retention and registry/observer caps; exposed via `controllerThreadBorderRouters`.
- **Device-type + Thread role icons** (`@mdi/js`): node glyph reflects the Matter device type with a role badge overlay; backend collects the primary application device type (skipping infra/aggregator types).
- **Border routers in the graph**: hostname/network-name labels, leader crown + primary-BBR star (decoded from MeshCoP state bitmap), and a rich details panel (vendor, model, Thread version, role, partition, addresses, observers).
- **External/unknown neighbors**: network name, best RSSI, observers; phantom hiding for stale single-observer ghosts.
- **LQI-primary edge colors** (OpenThread 0–3 scale), hide options, mesh search, per-node Thread version, full BSSID everywhere.
- **Localization**: all new node/edge/panel strings routed through I18n across all 11 languages.
- **Tooling fix**: `check-ts` was silently aborting on a config deprecation (so neither Vite nor eslint typechecked) — switched to `moduleResolution: bundler`, added `*.css` decl, and fixed the pre-existing type errors it surfaced.

## Verification
All gates green locally: `build:ts`, `lint`, `npm test` (62 passing), `check-ts`, `lint-frontend`, `build:gui`.

## Known follow-ups (non-blocking)
- `#getPrimaryDeviceType` runs per node per graph fetch (static data — could be memoized).
- Translations are proper for the new strings; broader pro-translation review optional.

🤖 Generated with [Claude Code](https://claude.com/claude-code)