### PR TITLE
perf: cache repeated cluster/attribute lookups in Matter hot paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,9 @@ Tests are located in the `test/` directory and use ts-node for direct TypeScript
 -->
 
 ## Changelog
+### **WORK IN PROGRESS**
+* (@Apollon77) Optimized Matter data processing by caching repeated cluster/attribute lookups in hot paths
+
 ### 1.2.1 (2026-06-29)
 * (@Apollon77) Fix Thermostat and WindowCovering state update errors
 * (@Apollon77) Update to the latest matter.js 0.17.4-alpha including MDNS/CPU usage fixes

--- a/src/matter/BridgedDevicesNode.ts
+++ b/src/matter/BridgedDevicesNode.ts
@@ -76,6 +76,8 @@ class BridgedDevices extends BaseServerNode {
             const name = mappingDevice.name;
             const endpoints = mappingDevice.matterEndpoints;
             const serialNumber = deviceOptions.uuid.replace(/-/g, '');
+            const matterName = name.substring(0, 32);
+            const productLabel = name.substring(0, 64);
             if (endpoints.length === 1 || deviceOptions.noComposed) {
                 let erroredCount = 0;
                 // When only one endpoint or non-composed we simply add all endpoints for itself to the bridge
@@ -92,11 +94,10 @@ class BridgedDevices extends BaseServerNode {
                         this.adapter.log.error(`Error closing endpoint ${endpoint.id} in bridge: ${errorText}`);
                     }
 
-                    const matterName = name.substring(0, 32);
                     endpoint.behaviors.require(BridgedDeviceBasicInformationServer, {
                         nodeLabel: matterName,
                         productName: matterName,
-                        productLabel: name.substring(0, 64),
+                        productLabel,
                         serialNumber,
                         uniqueId: md5(endpoint.id),
                         reachable: true,
@@ -130,13 +131,12 @@ class BridgedDevices extends BaseServerNode {
                     this.adapter.log.error(`Error closing endpoint ${id} in bridge: ${error}`);
                 }
 
-                const matterName = name.substring(0, 32);
                 const composedEndpoint = new Endpoint(BridgedNodeEndpoint, {
                     id,
                     bridgedDeviceBasicInformation: {
                         nodeLabel: matterName,
                         productName: matterName,
-                        productLabel: name.substring(0, 64),
+                        productLabel,
                         serialNumber,
                         uniqueId: md5(id),
                         reachable: true,

--- a/src/matter/GeneralMatterNode.ts
+++ b/src/matter/GeneralMatterNode.ts
@@ -53,7 +53,7 @@ export type PairedNodeConfig = {
     exposeMatterSystemClusterData: boolean;
 };
 
-const SystemClusters: ClusterId[] = [
+const SystemClusters = new Set<ClusterId>([
     ClusterId(0x0004), // Groups
     ClusterId(0x0005), // Scenes
     ClusterId(0x001d), // Descriptor
@@ -80,7 +80,7 @@ const SystemClusters: ClusterId[] = [
     ClusterId(0x003f), // Group Key Management
     ClusterId(0x0046), // ICD Management
     ClusterId(0x0062), // Scenes Management
-];
+]);
 
 export type GenericNodeConfiguration = {
     subscriptionMaxIntervalS?: number;
@@ -105,6 +105,7 @@ export class GeneralMatterNode {
     #endpointMap = new Map<number, { baseId: string; endpoint: Endpoint }>();
     #deviceMap = new Map<number, GenericDeviceToIoBroker>();
     #attributeTypeMap = new Map<string, ioBroker.CommonType>();
+    #attributeLeafIdMap = new Map<string, string>();
     #eventMap = new Set<string>();
     #subscriptions = new Map<string, SubscribeCallback>();
     #name?: string;
@@ -149,6 +150,7 @@ export class GeneralMatterNode {
 
         this.#endpointMap.clear();
         this.#attributeTypeMap.clear();
+        this.#attributeLeafIdMap.clear();
         this.#eventMap.clear();
     }
 
@@ -967,8 +969,17 @@ export class GeneralMatterNode {
     }
 
     #getAttributeStateLeafId(clusterId: number, attributeId: number, attrModel?: AttributeModel): string {
-        attrModel = attrModel ?? Matter.clusters(clusterId)?.attributes(attributeId);
-        return attrModel ? camelize(attrModel.name) : toHex(attributeId);
+        const cacheId = `${clusterId}.${attributeId}`;
+        if (attrModel === undefined) {
+            const cached = this.#attributeLeafIdMap.get(cacheId);
+            if (cached !== undefined) {
+                return cached;
+            }
+            attrModel = Matter.clusters(clusterId)?.attributes(attributeId);
+        }
+        const leafId = attrModel ? camelize(attrModel.name) : toHex(attributeId);
+        this.#attributeLeafIdMap.set(cacheId, leafId);
+        return leafId;
     }
 
     #getEventMapId(endpointId: number, clusterId: number, eventId: number): string {
@@ -980,6 +991,7 @@ export class GeneralMatterNode {
         clusterId: number,
         attributeId: number,
         isUnknown: boolean,
+        attrModel?: AttributeModel,
     ): { type: ioBroker.CommonType; states?: Record<number, string> } {
         const knownType = this.#attributeTypeMap.get(this.#getAttributeMapId(endpointId, clusterId, attributeId));
         if (knownType !== undefined) {
@@ -991,7 +1003,7 @@ export class GeneralMatterNode {
         if (isUnknown) {
             type = 'mixed';
         } else {
-            const attributeModel = Matter.clusters(clusterId)?.attributes(attributeId);
+            const attributeModel = attrModel ?? Matter.clusters(clusterId)?.attributes(attributeId);
             const effectiveType = attributeModel?.effectiveType;
             const metatype = attributeModel?.effectiveMetatype;
             if (metatype === undefined) {
@@ -1065,7 +1077,7 @@ export class GeneralMatterNode {
             }
             // TODO make Configurable
             const clusterBaseId = `${endpointBaseId}.${toHex(clusterId)}`;
-            if (!exposeMatterSystemClusterData && SystemClusters.includes(clusterId)) {
+            if (!exposeMatterSystemClusterData && SystemClusters.has(clusterId)) {
                 await this.adapter.delObjectAsync(clusterBaseId, { recursive: true });
                 continue;
             }
@@ -1118,6 +1130,7 @@ export class GeneralMatterNode {
                     clusterId,
                     attributeId,
                     unknown,
+                    attrModel,
                 );
                 const writable = attrModel?.effectiveAccess?.writable ?? false;
                 await this.adapter.extendObjectAsync(attributeBaseId, {

--- a/src/matter/to-iobroker/GenericDeviceToIoBroker.ts
+++ b/src/matter/to-iobroker/GenericDeviceToIoBroker.ts
@@ -92,6 +92,7 @@ export abstract class GenericDeviceToIoBroker<C extends CustomStatesRecord = Emp
     readonly #node: PairedNode;
     protected readonly appEndpoint: Endpoint;
     readonly #rootEndpoint: Endpoint;
+    readonly #behaviorIdCache = new Map<string, string | undefined>();
     #name?: string;
     #defaultName: string;
     readonly deviceType: string;
@@ -1026,23 +1027,29 @@ export abstract class GenericDeviceToIoBroker<C extends CustomStatesRecord = Emp
     }
 
     #getClusterState(endpointId: EndpointNumber, clusterId: ClusterId): Record<string, any> | undefined {
-        const ep = endpointId === 0 ? this.#rootEndpoint : this.appEndpoint;
-        for (const [behaviorId, BehaviorType] of Object.entries(ep.behaviors.supported)) {
-            if (ClusterBehavior.is(BehaviorType) && BehaviorType.cluster.id === clusterId) {
-                return (ep.state as any)[behaviorId];
-            }
+        const behaviorId = this.#getBehaviorId(endpointId, clusterId);
+        if (behaviorId === undefined) {
+            return undefined;
         }
-        return undefined;
+        const ep = endpointId === 0 ? this.#rootEndpoint : this.appEndpoint;
+        return (ep.state as any)[behaviorId];
     }
 
     #getBehaviorId(endpointId: EndpointNumber, clusterId: ClusterId): string | undefined {
+        const cacheKey = `${endpointId}:${clusterId}`;
+        if (this.#behaviorIdCache.has(cacheKey)) {
+            return this.#behaviorIdCache.get(cacheKey);
+        }
         const ep = endpointId === 0 ? this.#rootEndpoint : this.appEndpoint;
-        for (const [behaviorId, BehaviorType] of Object.entries(ep.behaviors.supported)) {
+        let behaviorId: string | undefined;
+        for (const [id, BehaviorType] of Object.entries(ep.behaviors.supported)) {
             if (ClusterBehavior.is(BehaviorType) && BehaviorType.cluster.id === clusterId) {
-                return behaviorId;
+                behaviorId = id;
+                break;
             }
         }
-        return undefined;
+        this.#behaviorIdCache.set(cacheKey, behaviorId);
+        return behaviorId;
     }
 
     getStatus(nodeStatus: DeviceStatus): DeviceStatus {

--- a/src/matter/to-matter/BlindsToMatter.ts
+++ b/src/matter/to-matter/BlindsToMatter.ts
@@ -30,7 +30,7 @@ type IoBrokerWindowCoveringDevice = typeof IoBrokerWindowCoveringDevice;
 export class BlindsToMatter extends GenericDeviceToMatter {
     readonly #ioBrokerDevice: BlindButtons | Blind;
     readonly #matterEndpoint: Endpoint<IoBrokerWindowCoveringDevice>;
-    #supportedFeatures = new Array<WindowCovering.Feature>();
+    #supportedFeatures = new Set<WindowCovering.Feature>();
     readonly #WindowCoveringServer;
 
     constructor(ioBrokerDevice: BlindButtons | Blind, name: string, uuid: string) {
@@ -39,15 +39,15 @@ export class BlindsToMatter extends GenericDeviceToMatter {
         this.#ioBrokerDevice = ioBrokerDevice;
 
         if (this.#ioBrokerDevice.hasLiftButtons() || this.#ioBrokerDevice.hasLiftLevel()) {
-            this.#supportedFeatures.push(WindowCovering.Feature.Lift);
+            this.#supportedFeatures.add(WindowCovering.Feature.Lift);
             if (this.#ioBrokerDevice.hasLiftLevel()) {
-                this.#supportedFeatures.push(WindowCovering.Feature.PositionAwareLift);
+                this.#supportedFeatures.add(WindowCovering.Feature.PositionAwareLift);
             }
         }
         if (this.#ioBrokerDevice.hasTiltButtons() || this.#ioBrokerDevice.hasTiltLevel()) {
-            this.#supportedFeatures.push(WindowCovering.Feature.Tilt);
+            this.#supportedFeatures.add(WindowCovering.Feature.Tilt);
             if (this.#ioBrokerDevice.hasTiltLevel()) {
-                this.#supportedFeatures.push(WindowCovering.Feature.PositionAwareTilt);
+                this.#supportedFeatures.add(WindowCovering.Feature.PositionAwareTilt);
             }
         }
 
@@ -60,15 +60,15 @@ export class BlindsToMatter extends GenericDeviceToMatter {
             },
             windowCovering: {
                 type:
-                    this.#supportedFeatures.includes(WindowCovering.Feature.Lift) &&
-                    this.#supportedFeatures.includes(WindowCovering.Feature.Tilt)
+                    this.#supportedFeatures.has(WindowCovering.Feature.Lift) &&
+                    this.#supportedFeatures.has(WindowCovering.Feature.Tilt)
                         ? WindowCovering.WindowCoveringType.TiltBlindLift
-                        : this.#supportedFeatures.includes(WindowCovering.Feature.Lift)
+                        : this.#supportedFeatures.has(WindowCovering.Feature.Lift)
                           ? WindowCovering.WindowCoveringType.Rollershade
                           : WindowCovering.WindowCoveringType.TiltBlindTiltOnly,
                 endProductType:
-                    this.#supportedFeatures.includes(WindowCovering.Feature.Lift) &&
-                    !this.#supportedFeatures.includes(WindowCovering.Feature.Tilt)
+                    this.#supportedFeatures.has(WindowCovering.Feature.Lift) &&
+                    !this.#supportedFeatures.has(WindowCovering.Feature.Tilt)
                         ? WindowCovering.EndProductType.RollerShade
                         : WindowCovering.EndProductType.Unknown,
             },
@@ -87,8 +87,8 @@ export class BlindsToMatter extends GenericDeviceToMatter {
         super.registerHandlersAndInitialize();
 
         if (
-            this.#supportedFeatures.includes(WindowCovering.Feature.Tilt) &&
-            this.#supportedFeatures.includes(WindowCovering.Feature.PositionAwareTilt)
+            this.#supportedFeatures.has(WindowCovering.Feature.Tilt) &&
+            this.#supportedFeatures.has(WindowCovering.Feature.PositionAwareTilt)
         ) {
             await this.#matterEndpoint.setStateOf(this.#WindowCoveringServer, {
                 currentPositionTiltPercent100ths: Math.round(100 - (this.#ioBrokerDevice.getTiltLevel() ?? 0)) * 100,
@@ -96,8 +96,8 @@ export class BlindsToMatter extends GenericDeviceToMatter {
             });
         }
         if (
-            this.#supportedFeatures.includes(WindowCovering.Feature.Lift) &&
-            this.#supportedFeatures.includes(WindowCovering.Feature.PositionAwareLift)
+            this.#supportedFeatures.has(WindowCovering.Feature.Lift) &&
+            this.#supportedFeatures.has(WindowCovering.Feature.PositionAwareLift)
         ) {
             await this.#matterEndpoint.setStateOf(this.#WindowCoveringServer, {
                 currentPositionLiftPercent100ths:
@@ -115,9 +115,9 @@ export class BlindsToMatter extends GenericDeviceToMatter {
                 direction: MovementDirection,
                 targetPercent100ths?: number,
             ) => {
-                if (type === MovementType.Lift && this.#supportedFeatures.includes(WindowCovering.Feature.Lift)) {
+                if (type === MovementType.Lift && this.#supportedFeatures.has(WindowCovering.Feature.Lift)) {
                     if (
-                        this.#supportedFeatures.includes(WindowCovering.Feature.PositionAwareLift) &&
+                        this.#supportedFeatures.has(WindowCovering.Feature.PositionAwareLift) &&
                         targetPercent100ths !== undefined &&
                         this.#ioBrokerDevice.hasLiftLevel()
                     ) {
@@ -137,12 +137,9 @@ export class BlindsToMatter extends GenericDeviceToMatter {
                             }
                         }
                     }
-                } else if (
-                    type === MovementType.Tilt &&
-                    this.#supportedFeatures.includes(WindowCovering.Feature.Tilt)
-                ) {
+                } else if (type === MovementType.Tilt && this.#supportedFeatures.has(WindowCovering.Feature.Tilt)) {
                     if (
-                        this.#supportedFeatures.includes(WindowCovering.Feature.PositionAwareTilt) &&
+                        this.#supportedFeatures.has(WindowCovering.Feature.PositionAwareTilt) &&
                         targetPercent100ths !== undefined &&
                         this.#ioBrokerDevice.hasTiltLevel()
                     ) {
@@ -167,20 +164,20 @@ export class BlindsToMatter extends GenericDeviceToMatter {
         );
 
         this.matterEvents.on(this.#matterEndpoint.events.ioBrokerEvents.windowCoveringStopMovement, async () => {
-            if (this.#supportedFeatures.includes(WindowCovering.Feature.Lift)) {
+            if (this.#supportedFeatures.has(WindowCovering.Feature.Lift)) {
                 if (this.#ioBrokerDevice.hasLiftStopButton()) {
                     await this.#ioBrokerDevice.setStop();
-                } else if (this.#supportedFeatures.includes(WindowCovering.Feature.PositionAwareLift)) {
+                } else if (this.#supportedFeatures.has(WindowCovering.Feature.PositionAwareLift)) {
                     const currentLevel = (this.#ioBrokerDevice as Blind).getLevel();
                     if (currentLevel !== undefined) {
                         await (this.#ioBrokerDevice as Blind).setLevel(currentLevel);
                     }
                 }
             }
-            if (this.#supportedFeatures.includes(WindowCovering.Feature.Tilt)) {
+            if (this.#supportedFeatures.has(WindowCovering.Feature.Tilt)) {
                 if (this.#ioBrokerDevice.hasTiltStopButton()) {
                     await this.#ioBrokerDevice.setTiltStop();
-                } else if (this.#supportedFeatures.includes(WindowCovering.Feature.PositionAwareTilt)) {
+                } else if (this.#supportedFeatures.has(WindowCovering.Feature.PositionAwareTilt)) {
                     const currentTiltLevel = this.#ioBrokerDevice.getTiltLevel();
                     if (currentTiltLevel !== undefined) {
                         await this.#ioBrokerDevice.setTiltLevel(currentTiltLevel);
@@ -195,8 +192,8 @@ export class BlindsToMatter extends GenericDeviceToMatter {
                 case PropertyType.TiltLevelActual: {
                     const percentage = event.value as number;
                     if (
-                        this.#supportedFeatures.includes(WindowCovering.Feature.Tilt) &&
-                        this.#supportedFeatures.includes(WindowCovering.Feature.PositionAwareTilt)
+                        this.#supportedFeatures.has(WindowCovering.Feature.Tilt) &&
+                        this.#supportedFeatures.has(WindowCovering.Feature.PositionAwareTilt)
                     ) {
                         await this.#matterEndpoint.setStateOf(this.#WindowCoveringServer, {
                             currentPositionTiltPercent100ths: Math.round(100 - percentage) * 100,
@@ -213,8 +210,8 @@ export class BlindsToMatter extends GenericDeviceToMatter {
                 case PropertyType.LevelActual: {
                     const percentage = event.value as number;
                     if (
-                        this.#supportedFeatures.includes(WindowCovering.Feature.Lift) &&
-                        this.#supportedFeatures.includes(WindowCovering.Feature.PositionAwareLift)
+                        this.#supportedFeatures.has(WindowCovering.Feature.Lift) &&
+                        this.#supportedFeatures.has(WindowCovering.Feature.PositionAwareLift)
                     ) {
                         await this.#matterEndpoint.setStateOf(this.#WindowCoveringServer, {
                             currentPositionLiftPercent100ths: Math.round(100 - percentage) * 100,


### PR DESCRIPTION
## What

Removes repeated expensive lookups from Matter data-processing hot paths, mirroring the fixes in matterjs-server [#788](https://github.com/matter-js/matterjs-server/pull/788) / [#793](https://github.com/matter-js/matterjs-server/pull/793) ("large sync loops and inefficient access to data"), scoped to the analogs that actually exist here.

Class A (synchronous event-loop blocking) was checked and is **not present** — our node walks are all `async` and `await` I/O per item, so they already yield. These changes are all Class B (repeated expensive access).

## Changes

| Path | Change | Frequency |
|------|--------|-----------|
| `GeneralMatterNode` | Cache attribute leaf-ids (`#attributeLeafIdMap`) — stops re-doing `Matter.clusters().attributes()` model lookup on every attribute report | hot (per report, raw-data mode) |
| `GenericDeviceToIoBroker` | Cache behavior-ids (`#behaviorIdCache`) — stops rebuilding + linear-scanning `Object.entries(behaviors.supported)` on every poll tick | hot (per poll) |
| `GeneralMatterNode` | `SystemClusters` array → `Set` (`.has` O(1)); thread `attrModel` into `#determineIoBrokerDatatype` to drop a redundant model refetch | init |
| `BlindsToMatter` | `#supportedFeatures` array → `Set` (20 lookups, several per movement command) | init + hot |
| `BridgedDevicesNode` | Hoist loop-invariant `name.substring()` out of the endpoint loop | init |

## Not changed (evaluated, judged not worth it)
- `HueAndRgbToMatter` state re-reads — branches are mutually exclusive `if/else if`, no real double-read.
- `ThermostatToMatter` `.includes` — array is mutated between the checks and post-mutation booleans are already cached; hoisting would alter logic for zero gain.

## Verification
- `npm run build` clean, `npm run lint` clean, `npm test` **69 passing**.
- Independent adversarial review over the cumulative diff: one item flagged (`#attributeLeafIdMap` returning a cached value when an explicit `attrModel` is passed) — validated as a non-bug (static deterministic model lookup → name invariant per key) but hardened anyway with a zero-cost guard so an explicit arg always wins. Set semantics, hoist invariance, and key-collision safety all confirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)