### PR TITLE
fix: register controller states only for attributes the device actually supports (#725)

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ Tests are located in the `test/` directory and use ts-node for direct TypeScript
 ## Changelog
 ### **WORK IN PROGRESS**
 * (@Apollon77) Optimized Matter data processing by caching repeated cluster/attribute lookups in hot paths
+* (@Apollon77) Only register additional custom attributes when the node supports them
 
 ### 1.2.1 (2026-06-29)
 * (@Apollon77) Fix Thermostat and WindowCovering state update errors

--- a/src/matter/to-iobroker/GenericDeviceToIoBroker.ts
+++ b/src/matter/to-iobroker/GenericDeviceToIoBroker.ts
@@ -257,7 +257,7 @@ export abstract class GenericDeviceToIoBroker<C extends CustomStatesRecord = Emp
                 : data.attributeName;
         if (attributeName !== undefined) {
             const clusterState = this.#getClusterState(endpointId, clusterId);
-            if (!clusterState || !(attributeName in clusterState)) {
+            if (!clusterState || clusterState[attributeName] === undefined) {
                 return;
             }
         }
@@ -302,7 +302,7 @@ export abstract class GenericDeviceToIoBroker<C extends CustomStatesRecord = Emp
                     : data.attributeName;
             if (endpointId !== undefined && clusterId !== undefined && attributeName !== undefined) {
                 const clusterState = this.#getClusterState(endpointId, clusterId);
-                if (!clusterState || !(attributeName in clusterState)) {
+                if (!clusterState || clusterState[attributeName] === undefined) {
                     return;
                 }
 
@@ -425,10 +425,12 @@ export abstract class GenericDeviceToIoBroker<C extends CustomStatesRecord = Emp
                     ? `unknownAttribute_${Diagnostic.hex(data.vendorSpecificAttributeId)}`
                     : data.attributeName;
 
-            // Verify the attribute exists on the cluster
+            // Verify the attribute exists on the cluster. The state key is present for every
+            // schema attribute, but non-conformant devices leave unsupported optional attributes
+            // undefined - so check the value, not just key presence (nullable attributes read null).
             if (endpointId !== undefined && clusterId !== undefined && attributeName !== undefined) {
                 const clusterState = this.#getClusterState(endpointId, clusterId);
-                if (!clusterState || !(attributeName in clusterState)) {
+                if (!clusterState || clusterState[attributeName] === undefined) {
                     return;
                 }
                 attributeId = Matter.clusters(clusterId)?.attributes.find(m => camelize(m.name) === attributeName)

--- a/src/matter/to-iobroker/GenericDeviceToIoBroker.ts
+++ b/src/matter/to-iobroker/GenericDeviceToIoBroker.ts
@@ -255,11 +255,8 @@ export abstract class GenericDeviceToIoBroker<C extends CustomStatesRecord = Emp
             'vendorSpecificAttributeId' in data
                 ? `unknownAttribute_${Diagnostic.hex(data.vendorSpecificAttributeId)}`
                 : data.attributeName;
-        if (attributeName !== undefined) {
-            const clusterState = this.#getClusterState(endpointId, clusterId);
-            if (!clusterState || clusterState[attributeName] === undefined) {
-                return;
-            }
+        if (attributeName !== undefined && !this.#attributeIsSupported(endpointId, clusterId, attributeName)) {
+            return;
         }
 
         if (attributeName === undefined) {
@@ -301,8 +298,7 @@ export abstract class GenericDeviceToIoBroker<C extends CustomStatesRecord = Emp
                     ? `unknownAttribute_${Diagnostic.hex(data.vendorSpecificAttributeId)}`
                     : data.attributeName;
             if (endpointId !== undefined && clusterId !== undefined && attributeName !== undefined) {
-                const clusterState = this.#getClusterState(endpointId, clusterId);
-                if (!clusterState || clusterState[attributeName] === undefined) {
+                if (!this.#attributeIsSupported(endpointId, clusterId, attributeName)) {
                     return;
                 }
 
@@ -425,12 +421,8 @@ export abstract class GenericDeviceToIoBroker<C extends CustomStatesRecord = Emp
                     ? `unknownAttribute_${Diagnostic.hex(data.vendorSpecificAttributeId)}`
                     : data.attributeName;
 
-            // Verify the attribute exists on the cluster. The state key is present for every
-            // schema attribute, but non-conformant devices leave unsupported optional attributes
-            // undefined - so check the value, not just key presence (nullable attributes read null).
             if (endpointId !== undefined && clusterId !== undefined && attributeName !== undefined) {
-                const clusterState = this.#getClusterState(endpointId, clusterId);
-                if (!clusterState || clusterState[attributeName] === undefined) {
+                if (!this.#attributeIsSupported(endpointId, clusterId, attributeName)) {
                     return;
                 }
                 attributeId = Matter.clusters(clusterId)?.attributes.find(m => camelize(m.name) === attributeName)
@@ -1026,6 +1018,16 @@ export abstract class GenericDeviceToIoBroker<C extends CustomStatesRecord = Emp
         } else if (typeof voltage === 'number') {
             return `${voltage}mV`;
         }
+    }
+
+    /**
+     * Whether the paired device actually supports the attribute. The state key is present for every
+     * schema attribute, but non-conformant devices leave unsupported optional attributes undefined -
+     * so check the value, not just key presence (supported nullable attributes read null).
+     */
+    #attributeIsSupported(endpointId: EndpointNumber, clusterId: ClusterId, attributeName: string): boolean {
+        const clusterState = this.#getClusterState(endpointId, clusterId);
+        return clusterState !== undefined && clusterState[attributeName] !== undefined;
     }
 
     #getClusterState(endpointId: EndpointNumber, clusterId: ClusterId): Record<string, any> | undefined {


### PR DESCRIPTION
## Problem

Addresses #725. Controller created writable ioBroker states (e.g. \`startUpOnOff\`) for Matter attributes the paired device does not actually support. Writing such a state made the device reject it:

\`\`\`
[unsupported-attribute] 1.onOff.state.startUpOnOff: Unsupported attribute
[conformance] "LT": Matter does not allow you to set this attribute
\`\`\`

## Root cause

matter.js derives a cluster \`State\` class with a property for **every** schema attribute, regardless of whether the specific paired device implements that optional attribute — the value is only \`undefined\` when the device lacks operational support. The existence guards used \`attributeName in clusterState\`, which is true for any conformant attribute name and so almost never filtered anything out. Unsupported optional attributes therefore got dead/writable ioBroker states.

## Fix

Check the attribute **value**, not key presence, in all three registration guards in \`GenericDeviceToIoBroker.ts\`:

\`\`\`ts
if (!clusterState || clusterState[attributeName] === undefined) {
    return;
}
\`\`\`

- Unsupported attribute → \`undefined\` → skipped.
- Supported nullable attribute read as \`null\` → \`null !== undefined\` → still registered.

Covers \`startUpOnOff\` and \`startUpCurrentLevel\` (custom states) plus the device-type registration paths.

## Verification

- \`npm run build\` OK
- \`npm run lint\` clean
- \`npm test\` — 69 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)