### PR TITLE
fix: correct Matter attribute names for electrical measurement (#716)

### DIFF
--- a/src/matter/to-iobroker/GenericDeviceToIoBroker.ts
+++ b/src/matter/to-iobroker/GenericDeviceToIoBroker.ts
@@ -282,7 +282,7 @@ export abstract class GenericDeviceToIoBroker<C extends CustomStatesRecord = Emp
             changeHandler?: (value: any) => MaybePromise<void> | void;
             pollAttribute?: boolean;
             modes?: { [key: string]: string };
-        } & ({ vendorSpecificAttributeId: AttributeId } | { attributeName?: string }),
+        } & ({ vendorSpecificAttributeId: AttributeId } | { attributeName?: string | string[] }),
     ): void {
         const stateData = this.#deviceOptions.additionalStateData![type] ?? {};
         if (stateData.id !== undefined) {
@@ -293,12 +293,16 @@ export abstract class GenericDeviceToIoBroker<C extends CustomStatesRecord = Emp
         if (data !== undefined) {
             const { endpointId, clusterId, convertValue, changeHandler, pollAttribute, modes } = data;
             let attributeId: AttributeId | undefined;
-            const attributeName =
+            const requestedAttributeName =
                 'vendorSpecificAttributeId' in data
                     ? `unknownAttribute_${Diagnostic.hex(data.vendorSpecificAttributeId)}`
                     : data.attributeName;
-            if (endpointId !== undefined && clusterId !== undefined && attributeName !== undefined) {
-                if (!this.#attributeIsSupported(endpointId, clusterId, attributeName)) {
+            let attributeName = Array.isArray(requestedAttributeName)
+                ? requestedAttributeName[0]
+                : requestedAttributeName;
+            if (endpointId !== undefined && clusterId !== undefined && requestedAttributeName !== undefined) {
+                attributeName = this.#firstSupportedAttributeName(endpointId, clusterId, requestedAttributeName);
+                if (attributeName === undefined) {
                     return;
                 }
 
@@ -1028,6 +1032,20 @@ export abstract class GenericDeviceToIoBroker<C extends CustomStatesRecord = Emp
     #attributeIsSupported(endpointId: EndpointNumber, clusterId: ClusterId, attributeName: string): boolean {
         const clusterState = this.#getClusterState(endpointId, clusterId);
         return clusterState !== undefined && clusterState[attributeName] !== undefined;
+    }
+
+    /**
+     * Resolve the attribute name to use when a state maps to several candidate attributes that depend
+     * on the cluster feature set (e.g. activeCurrent vs rmsCurrent). Returns the first candidate the
+     * device actually supports, or undefined when none is supported.
+     */
+    #firstSupportedAttributeName(
+        endpointId: EndpointNumber,
+        clusterId: ClusterId,
+        attributeName: string | string[],
+    ): string | undefined {
+        const candidates = Array.isArray(attributeName) ? attributeName : [attributeName];
+        return candidates.find(name => this.#attributeIsSupported(endpointId, clusterId, name));
     }
 
     #getClusterState(endpointId: EndpointNumber, clusterId: ClusterId): Record<string, any> | undefined {

--- a/src/matter/to-iobroker/GenericDeviceToIoBroker.ts
+++ b/src/matter/to-iobroker/GenericDeviceToIoBroker.ts
@@ -286,7 +286,7 @@ export abstract class GenericDeviceToIoBroker<C extends CustomStatesRecord = Emp
     ): void {
         const stateData = this.#deviceOptions.additionalStateData![type] ?? {};
         if (stateData.id !== undefined) {
-            console.log(`State ${type} already enabled`);
+            this.#adapter.log.debug(`State ${type} already enabled`);
             return;
         }
 
@@ -371,7 +371,7 @@ export abstract class GenericDeviceToIoBroker<C extends CustomStatesRecord = Emp
         const pathId = eventPathToString({ endpointId, clusterId, eventName });
         this.#deviceOptions.additionalStateData![type] = stateData;
         if (this.#matterMappings.get(pathId)) {
-            console.log(`State path ${pathId} already enabled, overwriting`);
+            this.#adapter.log.warn(`State path ${pathId} already enabled, overwriting`);
         }
         this.#matterMappings.set(pathId, type);
         const knownEvents = this.#enabledEventProperties.get(type) ?? [];

--- a/src/matter/to-iobroker/GenericElectricityDataDeviceToIoBroker.ts
+++ b/src/matter/to-iobroker/GenericElectricityDataDeviceToIoBroker.ts
@@ -41,13 +41,13 @@ export abstract class GenericElectricityDataDeviceToIoBroker<
             this.enableDeviceTypeStateForAttribute(PropertyType.Current, {
                 endpointId,
                 clusterId,
-                attributeName: 'rmsCurrent',
+                attributeName: ['activeCurrent', 'rmsCurrent'],
                 convertValue: value => value / 1000,
             });
             this.enableDeviceTypeStateForAttribute(PropertyType.Voltage, {
                 endpointId,
                 clusterId,
-                attributeName: 'rmsVoltage',
+                attributeName: ['voltage', 'rmsVoltage'],
                 convertValue: value => value / 1000,
             });
             this.enableDeviceTypeStateForAttribute(PropertyType.Frequency, {

--- a/src/matter/to-iobroker/GenericElectricityDataDeviceToIoBroker.ts
+++ b/src/matter/to-iobroker/GenericElectricityDataDeviceToIoBroker.ts
@@ -41,13 +41,13 @@ export abstract class GenericElectricityDataDeviceToIoBroker<
             this.enableDeviceTypeStateForAttribute(PropertyType.Current, {
                 endpointId,
                 clusterId,
-                attributeName: 'activeCurrent',
-                // No conversion because also our default unit is mA
+                attributeName: 'rmsCurrent',
+                convertValue: value => value / 1000,
             });
             this.enableDeviceTypeStateForAttribute(PropertyType.Voltage, {
                 endpointId,
                 clusterId,
-                attributeName: 'voltage',
+                attributeName: 'rmsVoltage',
                 convertValue: value => value / 1000,
             });
             this.enableDeviceTypeStateForAttribute(PropertyType.Frequency, {
@@ -65,7 +65,8 @@ export abstract class GenericElectricityDataDeviceToIoBroker<
             this.enableDeviceTypeStateForAttribute(PropertyType.Consumption, {
                 endpointId,
                 clusterId: ElectricalEnergyMeasurement.id,
-                attributeName: 'cumulativeEnergy',
+                attributeName: 'cumulativeEnergyImported',
+                convertValue: value => Number(value?.energy ?? 0) / 1000,
             });
             found = true;
         }


### PR DESCRIPTION
## Problem

Tapo P110M (and other AC measuring plugs) exposed only **power** in the controller — no current, voltage or energy — although the Matter clusters are present (#716).

`GenericElectricityDataDeviceToIoBroker` requested attributes under names that only fit part of the device landscape:
- `activeCurrent` / `voltage` exist on non-ALTC (DC-style) devices; ALTC devices instead expose `rmsCurrent` / `rmsVoltage`.
- `cumulativeEnergy` does not exist at all — the real attribute is `cumulativeEnergyImported` (a struct).

The attribute-support guard silently dropped every state whose name the device didn't implement, so only `activePower` survived.

## Fix

- `enableDeviceTypeStateForAttribute` now accepts a **list of candidate attribute names**; it uses the first one the device actually supports (`#firstSupportedAttributeName`, built on the existing `#attributeIsSupported` value check from #829). This keeps DC devices (`activeCurrent`/`voltage`) working while also serving ALTC devices (`rmsCurrent`/`rmsVoltage`).
- Current → `['activeCurrent', 'rmsCurrent']`, Voltage → `['voltage', 'rmsVoltage']`.
- Consumption → `cumulativeEnergyImported`, extracting `.energy` (mWh → Wh).
- `rmsCurrent`/`activeCurrent` now converted mA → A (state unit is A; previously unconverted — a pre-existing 1000× error).
- Drive-by: the two duplicate-state-registration messages now go through the adapter logger (`debug` / `warn`) instead of `console.log`.

Verified against the endpoint dump in #716: `rmsVoltage` 230608 → 230.6 V, `cumulativeEnergyImported.energy` 94000 → 94 Wh.

## Note on the missing on/off switch in #716

Separate, **already-fixed** issue: v1.0.0 read `endpoint.getDeviceTypes()`, which returned only the endpoint's primary type (ElectricalSensor, utility) and hid the OnOffPlugInUnit application type. Fixed in #801 (matter.js 0.17), shipped v1.1.0+. Reporter needs to update to get the switch back; this PR adds the remaining measurement values on top.

## Testing

- `npm run build:ts` clean
- `npm run lint` clean
- `npm test` — 69 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)