### PR TITLE
fix(controller): prefer BridgedNode when an endpoint declares several utility device types

### DIFF
--- a/src/matter/ControllerNode.ts
+++ b/src/matter/ControllerNode.ts
@@ -1342,13 +1342,13 @@ class Controller implements GeneralNode {
             collect(rootEndpoint);
             let fallback: number | undefined;
             for (const endpoint of endpoints) {
-                const { appTypes, utilityTypes } = identifyDeviceTypes(endpoint);
+                const { appTypes, primaryDeviceType } = identifyDeviceTypes(endpoint);
                 const appType = appTypes.find(t => !INFRA_DEVICE_TYPES.has(t.deviceType.id));
                 if (appType !== undefined) {
                     return appType.deviceType.id;
                 }
                 if (fallback === undefined) {
-                    fallback = appTypes[0]?.deviceType.id ?? utilityTypes[0]?.deviceType.id;
+                    fallback = primaryDeviceType?.deviceType.id;
                 }
             }
             return fallback;

--- a/src/matter/GeneralMatterNode.ts
+++ b/src/matter/GeneralMatterNode.ts
@@ -44,7 +44,7 @@ import type { SubscribeCallback } from '../lib/SubscribeManager';
 import { bytesToIpV4, bytesToIpV6, bytesToMac, decamelize, toHex, toUpperCaseHex } from '../lib/utils';
 import type { MatterAdapter } from '../main';
 import type { GenericDeviceToIoBroker } from './to-iobroker/GenericDeviceToIoBroker';
-import ioBrokerDeviceFabric, { identifyDeviceTypes } from './to-iobroker/ioBrokerFactory';
+import ioBrokerDeviceFabric, { childEndpointsAreOwnDevices, identifyDeviceTypes } from './to-iobroker/ioBrokerFactory';
 import type { StructuredJsonFormData } from '../lib/JsonConfigUtils';
 import type { DeviceStatus, ConfigConnectionType } from '@iobroker/dm-utils';
 import { VendorIds } from '../lib/vendorIDs';
@@ -176,7 +176,12 @@ export class GeneralMatterNode {
         this.#subscriptions.clear();
 
         for (const device of this.#deviceMap.values()) {
-            await device.destroy();
+            // One endpoint that fails to tear down must not leave the rest of the node half destroyed
+            try {
+                await device.destroy();
+            } catch (error) {
+                this.adapter.log.warn(`Node ${this.nodeId}: Error destroying device: ${error}`);
+            }
         }
         this.#deviceMap.clear();
 
@@ -845,6 +850,9 @@ export class GeneralMatterNode {
             endpointBaseName?: string;
         },
     ): Promise<void> {
+        // Redetected below, but a node that lost its aggregator must not keep reporting one
+        this.#hasAggregatorEndpoint = false;
+
         await this.#endpointToIoBrokerDevices(rootEndpoint, rootEndpoint, this.nodeBaseId, options);
 
         for (const childEndpoint of rootEndpoint.parts) {
@@ -869,7 +877,8 @@ export class GeneralMatterNode {
             return;
         }
 
-        const { appTypes, primaryDeviceType } = identifyDeviceTypes(endpoint);
+        const deviceTypes = identifyDeviceTypes(endpoint);
+        const { appTypes, primaryDeviceType } = deviceTypes;
         if (appTypes.length > 1) {
             this.adapter.log.info(
                 `Node ${this.node.nodeId}: Multiple device types detected: ${appTypes.map(t => t.deviceType.name).join(', ')}`,
@@ -895,9 +904,6 @@ export class GeneralMatterNode {
             existingObject?.native?.exposeMatterSystemClusterData ?? options?.exposeMatterSystemClusterData;
         let customExposeMatterApplicationClusterData =
             existingObject?.native?.exposeMatterApplicationClusterData ?? options?.exposeMatterApplicationClusterData;
-        let exposeMatterApplicationClusterData =
-            customExposeMatterApplicationClusterData ?? this.exposeMatterApplicationClusterData;
-
         let connectionStateId = options?.connectionStateId ?? `${this.adapter.namespace}.${this.connectionStateId}`;
 
         // TODO: Add TagList support
@@ -909,6 +915,13 @@ export class GeneralMatterNode {
                 : options?.endpointBaseName
                   ? `${options?.endpointBaseName} - ${endpointName ?? '???'}`
                   : (endpointName ?? '???');
+
+        const childrenAreOwnDevices = childEndpointsAreOwnDevices(id, deviceTypes);
+        // Read at recursion time: the bridged node below assigns its own connection state first
+        const childOptions = (): { connectionStateId: string; endpointBaseName?: string } => ({
+            connectionStateId,
+            endpointBaseName,
+        });
 
         if (primaryDeviceType === undefined) {
             this.adapter.log.warn(
@@ -940,7 +953,7 @@ export class GeneralMatterNode {
                 },
             });
 
-            if (primaryDeviceType.deviceType.name === 'BridgedNode') {
+            if (primaryDeviceType.deviceType.id === BridgedNodeEndpointDefinition.deviceType) {
                 const ioBrokerDevice = await ioBrokerDeviceFabric(
                     this.node,
                     endpoint,
@@ -950,18 +963,19 @@ export class GeneralMatterNode {
                     connectionStateId,
                     endpointBaseName ?? String(endpoint.type?.name ?? endpoint.number),
                 );
-                if (ioBrokerDevice !== null) {
-                    connectionStateId = ioBrokerDevice.connectionStateId;
-                    this.#deviceMap.set(id, ioBrokerDevice);
-                }
+                connectionStateId = ioBrokerDevice.connectionStateId;
+                this.#deviceMap.set(id, ioBrokerDevice);
             }
 
-            for (const childEndpoint of endpoint.parts) {
-                // Recursive call to process all sub endpoints for raw states
-                await this.#endpointToIoBrokerDevices(childEndpoint, rootEndpoint, endpointDeviceBaseId, {
-                    connectionStateId,
-                    endpointBaseName,
-                });
+            if (childrenAreOwnDevices) {
+                for (const childEndpoint of [...endpoint.parts]) {
+                    await this.#endpointToIoBrokerDevices(
+                        childEndpoint,
+                        rootEndpoint,
+                        endpointDeviceBaseId,
+                        childOptions(),
+                    );
+                }
             }
         } else {
             await this.adapter.extendObjectAsync(endpointDeviceBaseId, {
@@ -986,19 +1000,33 @@ export class GeneralMatterNode {
                     connectionStateId,
                     endpointBaseName ?? String(endpoint.type?.name ?? endpoint.number),
                 );
-                if (ioBrokerDevice !== null) {
-                    this.#deviceMap.set(id, ioBrokerDevice);
-                } else {
-                    // We expose the matter application data on the endpoint level
-                    if (!exposeMatterApplicationClusterData) {
-                        exposeMatterApplicationClusterData = true;
-                        customExposeMatterApplicationClusterData = true;
+                connectionStateId = ioBrokerDevice.connectionStateId;
+                this.#deviceMap.set(id, ioBrokerDevice);
 
-                        await this.adapter.extendObjectAsync(endpointDeviceBaseId, {
-                            native: {
-                                exposeMatterApplicationClusterData,
-                            },
-                        });
+                if (
+                    !ioBrokerDevice.deviceTypeSupported &&
+                    customExposeMatterApplicationClusterData === undefined &&
+                    !this.exposeMatterApplicationClusterData
+                ) {
+                    // Without a mapping the raw application clusters are the only access to this endpoint.
+                    // Only when the user has not decided yet - an explicit No has to stick.
+                    customExposeMatterApplicationClusterData = true;
+
+                    await this.adapter.extendObjectAsync(endpointDeviceBaseId, {
+                        native: {
+                            exposeMatterApplicationClusterData: true,
+                        },
+                    });
+                }
+
+                if (childrenAreOwnDevices) {
+                    for (const childEndpoint of [...endpoint.parts]) {
+                        await this.#endpointToIoBrokerDevices(
+                            childEndpoint,
+                            rootEndpoint,
+                            endpointDeviceBaseId,
+                            childOptions(),
+                        );
                     }
                 }
             }

--- a/src/matter/to-iobroker/GenericDeviceToIoBroker.ts
+++ b/src/matter/to-iobroker/GenericDeviceToIoBroker.ts
@@ -8,6 +8,7 @@ import {
     Diagnostic,
     EndpointNumber,
     Matter,
+    ObserverGroup,
 } from '@matter/main';
 import type { MatterAdapter } from '../../main';
 import { BasicInformation, BridgedDeviceBasicInformation, PowerSource } from '@matter/main/clusters';
@@ -91,6 +92,7 @@ export abstract class GenericDeviceToIoBroker<C extends CustomStatesRecord = Emp
     readonly #node: PairedNode;
     protected readonly appEndpoint: Endpoint;
     readonly #rootEndpoint: Endpoint;
+    readonly #observers = new ObserverGroup();
     readonly #behaviorIdCache = new Map<string, string | undefined>();
     #name?: string;
     #defaultName: string;
@@ -175,6 +177,11 @@ export abstract class GenericDeviceToIoBroker<C extends CustomStatesRecord = Emp
         return this.#connectionStateId;
     }
 
+    /** Whether the Matter device type of this endpoint has a dedicated ioBroker mapping. */
+    get deviceTypeSupported(): boolean {
+        return true;
+    }
+
     get nodeBasicInformation(): Record<string, unknown> {
         return this.#node.basicInformation ?? {};
     }
@@ -231,9 +238,10 @@ export abstract class GenericDeviceToIoBroker<C extends CustomStatesRecord = Emp
             convertValue: value => Math.round(value / 2),
             pollAttribute: true,
         });
-        endpoint
-            .eventsOf(PowerSourceClient)
-            .batPercentRemaining$Changed?.on(() => this.#adapter.refreshControllerDevices());
+        const batteryChanged = endpoint.eventsOf(PowerSourceClient).batPercentRemaining$Changed;
+        if (batteryChanged !== undefined) {
+            this.#observers.on(batteryChanged, () => this.#adapter.refreshControllerDevices());
+        }
         return true;
     }
 
@@ -904,8 +912,14 @@ export abstract class GenericDeviceToIoBroker<C extends CustomStatesRecord = Emp
             this.#adapter.clearTimeout(this.#pollTimeout);
             this.#pollTimeout = undefined;
         }
+        this.#observers.close();
         if (this.#hasBridgedReachabilityAttribute) {
-            await this.#adapter.setState(this.#connectionStateId, { val: false, ack: true });
+            // Unsubscribing must happen even when the connection state can no longer be written
+            try {
+                await this.#adapter.setState(this.#connectionStateId, { val: false, ack: true });
+            } catch (error) {
+                this.#adapter.log.warn(`Error setting connection state ${this.#connectionStateId}: ${error}`);
+            }
         }
         return this.ioBrokerDevice.destroy();
     }

--- a/src/matter/to-iobroker/UtilityOnlyToIoBroker.ts
+++ b/src/matter/to-iobroker/UtilityOnlyToIoBroker.ts
@@ -44,6 +44,10 @@ export class UtilityOnlyToIoBroker extends GenericElectricityDataDeviceToIoBroke
         );
     }
 
+    override get deviceTypeSupported(): boolean {
+        return this.#deviceTypeSupported;
+    }
+
     override get ioBrokerDeviceType(): string | undefined {
         return 'ElectricityDataDevice';
     }
@@ -54,7 +58,6 @@ export class UtilityOnlyToIoBroker extends GenericElectricityDataDeviceToIoBroke
                 // Electrical sensor icon
                 return 'data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAyNCI+DQogICAgPHBhdGggZmlsbD0iY3VycmVudENvbG9yIiBkPSJtMjIgMjAuNTktNC42OS00LjY5QzE4LjM3IDE0LjU1IDE5IDEyLjg1IDE5IDExYzAtNC40Mi0zLjU4LTgtOC04LTQuMDggMC03LjQ0IDMuMDUtNy45MyA3aDIuMDJDNS41NyA3LjE3IDguMDMgNSAxMSA1YzMuMzEgMCA2IDIuNjkgNiA2cy0yLjY5IDYtNiA2Yy0yLjQyIDAtNC41LTEuNDQtNS40NS0zLjVIMy40QzQuNDUgMTYuNjkgNy40NiAxOSAxMSAxOWMxLjg1IDAgMy41NS0uNjMgNC45LTEuNjlMMjAuNTkgMjJ6IiAvPg0KICAgIDxwYXRoIGZpbGw9ImN1cnJlbnRDb2xvciIgZD0iTTguNDMgOS42OSA5LjY1IDE1aDEuNjRsMS4yNi0zLjc4Ljk1IDIuMjhoMlYxMmgtMWwtMS4yNS0zaC0xLjU0bC0xLjEyIDMuMzdMOS4zNSA3SDcuN2wtMS4yNSA0SDF2MS41aDYuNTV6IiAvPg0KPC9zdmc+';
             case 'BridgedNode':
-                return 'node';
             case 'PowerSource': {
                 const powerSource = this.appEndpoint.maybeStateOf(PowerSourceClient);
                 if (powerSource) {
@@ -62,10 +65,16 @@ export class UtilityOnlyToIoBroker extends GenericElectricityDataDeviceToIoBroke
                     if ((features?.battery && !features?.wired) || powerSource.batChargeLevel !== undefined) {
                         // Battery icon
                         return 'data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAyNCI+DQogICAgPHBhdGggZmlsbD0iY3VycmVudENvbG9yIiBkPSJNMTUuNjcgNEgxNFYyaC00djJIOC4zM0M3LjYgNCA3IDQuNiA3IDUuMzN2MTUuMzNDNyAyMS40IDcuNiAyMiA4LjMzIDIyaDcuMzNjLjc0IDAgMS4zNC0uNiAxLjM0LTEuMzNWNS4zM0MxNyA0LjYgMTYuNCA0IDE1LjY3IDQiIC8+DQo8L3N2Zz4=';
-                    } else if (features?.wired || powerSource.wiredCurrentType !== undefined) {
+                    } else if (
+                        this.deviceType !== 'BridgedNode' &&
+                        (features?.wired || powerSource.wiredCurrentType !== undefined)
+                    ) {
                         // Wired icon
                         return 'data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAyNCI+DQogICAgPHBhdGggZmlsbD0iY3VycmVudENvbG9yIiBkPSJNMTYuMDEgNyAxNiAzaC0ydjRoLTRWM0g4djRoLS4wMUM3IDYuOTkgNiA3Ljk5IDYgOC45OXY1LjQ5TDkuNSAxOHYzaDV2LTNsMy41LTMuNTF2LTUuNWMwLTEtMS0yLTEuOTktMS45OSIgLz4NCjwvc3ZnPg==';
                     }
+                }
+                if (this.deviceType === 'BridgedNode') {
+                    return 'node';
                 }
             }
             // eslint-disable-next-line no-fallthrough

--- a/src/matter/to-iobroker/ioBrokerFactory.ts
+++ b/src/matter/to-iobroker/ioBrokerFactory.ts
@@ -49,9 +49,38 @@ export function identifyDeviceTypes(endpoint: Endpoint): {
             appTypes.push({ deviceType: deviceTypeDetails, revision: deviceType.revision });
         }
     });
-    const primaryDeviceType = appTypes.length > 0 ? appTypes[0] : utilityTypes[0];
+    // The deviceTypeList order is not defined by the specification, and child endpoints are only
+    // traversed when BridgedNode is the primary type - so it wins over the other utility types.
+    const primaryUtilityType =
+        utilityTypes.find(({ deviceType }) => deviceType.id === Endpoints.BridgedNodeEndpointDefinition.deviceType) ??
+        utilityTypes[0];
+    const primaryDeviceType = appTypes.length > 0 ? appTypes[0] : primaryUtilityType;
 
     return { utilityTypes, appTypes, primaryDeviceType };
+}
+
+/**
+ * Whether the child endpoints of an endpoint are devices in their own right, or parts the endpoint owns.
+ *
+ * The children of the root endpoint are walked by the caller, and an endpoint without a known device type
+ * produces no objects to hang them under.
+ */
+export function childEndpointsAreOwnDevices(
+    endpointId: number,
+    { appTypes, primaryDeviceType }: ReturnType<typeof identifyDeviceTypes>,
+): boolean {
+    if (endpointId === 0 || primaryDeviceType === undefined) {
+        return false;
+    }
+    if (
+        primaryDeviceType.deviceType.id === Endpoints.AggregatorEndpointDefinition.deviceType ||
+        primaryDeviceType.deviceType.id === Endpoints.BridgedNodeEndpointDefinition.deviceType
+    ) {
+        return true;
+    }
+    // Only utility types make the endpoint a composition whose children carry the application types.
+    // An application type means the endpoint is the device and its parts belong to it.
+    return appTypes.length === 0;
 }
 
 /**
@@ -65,7 +94,7 @@ async function ioBrokerDeviceFabric(
     endpointDeviceBaseId: string,
     defaultConnectionStateId: string,
     endpointName: string,
-): Promise<any> {
+): Promise<GenericDeviceToIoBroker<any>> {
     const { primaryDeviceType, utilityTypes } = identifyDeviceTypes(endpoint);
 
     const fullEndpointDeviceBaseId = `${adapter.namespace}.${endpointDeviceBaseId}`;

--- a/test/deviceTypeIdentification.test.ts
+++ b/test/deviceTypeIdentification.test.ts
@@ -1,0 +1,82 @@
+import { strictEqual } from 'node:assert';
+import type { Endpoint } from '@matter/main';
+import { childEndpointsAreOwnDevices, identifyDeviceTypes } from '../src/matter/to-iobroker/ioBrokerFactory';
+
+const AGGREGATOR = 0x000e;
+const POWER_SOURCE = 0x0011;
+const BRIDGED_NODE = 0x0013;
+const OCCUPANCY_SENSOR = 0x0107;
+
+function endpointWithDeviceTypes(...deviceTypes: number[]): Endpoint {
+    const state = { deviceTypeList: deviceTypes.map(deviceType => ({ deviceType, revision: 1 })) };
+    return { stateOf: () => state } as unknown as Endpoint;
+}
+
+describe('identifyDeviceTypes', () => {
+    it('splits application and utility device types', () => {
+        const { appTypes, utilityTypes } = identifyDeviceTypes(endpointWithDeviceTypes(OCCUPANCY_SENSOR, POWER_SOURCE));
+        strictEqual(appTypes.length, 1);
+        strictEqual(appTypes[0].deviceType.id, OCCUPANCY_SENSOR);
+        strictEqual(utilityTypes.length, 1);
+        strictEqual(utilityTypes[0].deviceType.id, POWER_SOURCE);
+    });
+
+    it('prefers an application device type over any utility device type', () => {
+        const { primaryDeviceType } = identifyDeviceTypes(
+            endpointWithDeviceTypes(BRIDGED_NODE, POWER_SOURCE, OCCUPANCY_SENSOR),
+        );
+        strictEqual(primaryDeviceType?.deviceType.id, OCCUPANCY_SENSOR);
+    });
+
+    it('prefers BridgedNode over another utility type declared first', () => {
+        // Aqara M3 declares [PowerSource, BridgedNode]; picking PowerSource loses all child endpoints.
+        const { primaryDeviceType } = identifyDeviceTypes(endpointWithDeviceTypes(POWER_SOURCE, BRIDGED_NODE));
+        strictEqual(primaryDeviceType?.deviceType.id, BRIDGED_NODE);
+    });
+
+    it('treats Aggregator as an application device type', () => {
+        const { appTypes, primaryDeviceType } = identifyDeviceTypes(endpointWithDeviceTypes(POWER_SOURCE, AGGREGATOR));
+        strictEqual(appTypes[0]?.deviceType.id, AGGREGATOR);
+        strictEqual(primaryDeviceType?.deviceType.id, AGGREGATOR);
+    });
+
+    it('falls back to the first utility type when no composition type is declared', () => {
+        const { primaryDeviceType } = identifyDeviceTypes(endpointWithDeviceTypes(POWER_SOURCE));
+        strictEqual(primaryDeviceType?.deviceType.id, POWER_SOURCE);
+    });
+
+    it('returns no primary device type for an endpoint without device types', () => {
+        const { primaryDeviceType } = identifyDeviceTypes(endpointWithDeviceTypes());
+        strictEqual(primaryDeviceType, undefined);
+    });
+});
+
+describe('childEndpointsAreOwnDevices', () => {
+    const forEndpoint = (endpointId: number, ...deviceTypes: number[]): boolean =>
+        childEndpointsAreOwnDevices(endpointId, identifyDeviceTypes(endpointWithDeviceTypes(...deviceTypes)));
+
+    it('treats a bridged node as a composition', () => {
+        strictEqual(forEndpoint(3, POWER_SOURCE, BRIDGED_NODE), true);
+    });
+
+    it('treats an aggregator as a composition', () => {
+        strictEqual(forEndpoint(1, AGGREGATOR), true);
+    });
+
+    it('treats a utility-only endpoint as a composition', () => {
+        strictEqual(forEndpoint(3, POWER_SOURCE), true);
+    });
+
+    it('lets an endpoint with an application device type own its parts', () => {
+        strictEqual(forEndpoint(3, OCCUPANCY_SENSOR), false);
+        strictEqual(forEndpoint(3, BRIDGED_NODE, OCCUPANCY_SENSOR), false);
+    });
+
+    it('leaves the children of the root endpoint to the caller', () => {
+        strictEqual(forEndpoint(0, AGGREGATOR), false);
+    });
+
+    it('claims nothing for an endpoint without a known device type', () => {
+        strictEqual(forEndpoint(3), false);
+    });
+});


### PR DESCRIPTION
Addresses #860

## Problem

`identifyDeviceTypes()` chose the primary device type of a utility-only endpoint as `utilityTypes[0]` — the raw order of the Descriptor `deviceTypeList`, which the specification does not define.

The Aqara M3 declares its bridged endpoints as `[PowerSource (0x11), BridgedNode (0x13)]`. Both are classified as Utility, so the primary type became `PowerSource`. In `GeneralMatterNode.#endpointToIoBrokerDevices()` only the Aggregator/BridgedNode branch descends into `endpoint.parts`, so the endpoint took the plain-device branch and all of its child endpoints were dropped. From the reporter's log:

```
Endpoint 3 to ioBroker Devices ep3 / PowerSource
```

with no lines for endpoints 4-7, although `ep3` reports `partsList: 4 5 6 7`. Only the battery of the FP300 arrived in ioBroker; occupancy and illuminance never did.

## Not a matter.js migration regression

The issue is titled as a regression since 0.5.6, but the 0.15.6 device API behaved the same way: `PairedNode.#createDevice()` maps `deviceTypeList` in wire order and `Endpoint.setDeviceTypes()` only dedupes by code — it never reorders. The 0.5.6 version of `identifyDeviceTypes()` was identical apart from the API call. So 0.5.6 produced `BridgedNode-3` because the hub did not yet declare a `PowerSource` device type on that endpoint. The adapter has always been order-fragile here; a firmware change exposed it.

## Fix

`BridgedNode` wins over the other utility device types when an endpoint declares no application device type. Application device types keep priority, as before.

This restores the object ids used before 1.0, so paths such as `Aggregator-1.BridgedNode-3.OccupancySensor-6.ACTUAL` come back.

Batteries are unaffected: `#enablePowerSourceStates()` reads the `PowerSource` cluster off the endpoint regardless of which device type is primary.

## Composed endpoints

Whether the children of an endpoint are devices of their own now lives in one place, `childEndpointsAreOwnDevices()`:

- an endpoint declaring **only utility types** is a composition — its children carry the application types and become devices of their own,
- an **application device type** means the endpoint is the device and owns its parts, which stay raw data below it,
- the children of the root endpoint belong to the caller, which also removes a latent double walk of every root child if a root endpoint ever declared an Aggregator type.

Before this, only Aggregator and BridgedNode endpoints descended, so the children of any other utility-only endpoint were invisible.

## Also in here

All of these are reachable from the change above:

- `#hasAggregatorEndpoint` is reset when the endpoint structure is rebuilt. It could previously only ever be turned on.
- A `BridgedNode` endpoint carrying a battery `PowerSource` keeps the battery icon instead of falling back to the generic node icon.
- The `BridgedNode` device type is compared by id instead of by name.
- The node device type fallback in `ControllerNode` uses the same primary type as the object tree, so icon and object tree cannot disagree.
- The `batPercentRemaining$Changed` observer is registered through a matter.js `ObserverGroup` and released in `destroy()` via `close()`. Every rebuild used to leave its callbacks behind, and devices without an own `PowerSource` all register on the root endpoint, so they accumulated. The group holds the observable itself, so teardown never calls `eventsOf()` again — that throws once the peer has dropped the cluster, and the throw would have aborted `GeneralMatterNode.clear()` half-way.
- `ioBrokerDeviceFabric()` has a concrete return type instead of `any`. It never returned `null`, so the branch that exposed the application clusters of an unmapped device type was dead code and the promise in the log was never kept. It is now driven by a `deviceTypeSupported` getter, and only fires when the user has not decided — an explicit *No* in the device configuration is no longer overwritten on the next restart.
- `clear()` keeps tearing down the remaining devices when one of them throws, and `destroy()` unsubscribes even when the connection state can no longer be written.

## Known consequences

Neither is migrated. Both leave objects behind that are never updated again; they can be deleted manually.

- The endpoint object id contains the primary device type name, so an affected endpoint moves from `PowerSource-<n>` to `BridgedNode-<n>`.
- Endpoints that become devices for the first time appear as new objects.

A migration for the rename was written and then dropped: recursively deleting the old tree also destroys child states and their `common.custom` history configuration, and since `appTypes[0]` is equally order-dependent, any runtime device type reorder would trigger that deletion again. That needs its own change with a proper subtree copy and tests.

## Deliberately cut from this PR

Two further fixes were implemented and then reverted, because each review round found a new class of regression in them rather than a detail to polish. They are real problems and deserve their own change:

- **The raw data tree of a bridged child is built twice** — once below the child's device folder and once below the parent as `<parent>.data.data.<p>-<c>` — and because the parent's walk runs second it wins `#endpointMap`, so the copy below the device is created and then never updated. Suppressing the second walk requires the parent's exposure setting to reach the children, and forwarding that setting turns an explicit *No* on a bridge into a recursive delete of child data that previous versions had created. Left exactly as on main.
- **A throw inside `device.init()` leaks the half-built device** — it never reaches `#deviceMap`, so `clear()` can never destroy it, and its observers and ioBroker subscriptions stay live for the process lifetime. Destroying it from the factory is not safe yet: until `init()` rebinds it, the device's connection state id still points at the *node's* `info.connection`, so the cleanup would mark a healthy node offline.

## Tests

`test/deviceTypeIdentification.test.ts` covers the device type selection and the composition rule. Both are mutation-checked: reverting the primary type selection fails with `17 !== 19`, and dropping the `appTypes.length === 0` gate fails the application-device-type case. The endpoint walk itself has no test.

## Found while reviewing, not addressed here

- `GeneralMatterNode.clear()` and the endpoint walk iterate `endpoint.parts` across many awaits. `structureChanged` firing mid-walk can leave a node half built until the next rebuild.
- Selecting *Default* for the application cluster data of an unmapped endpoint writes `null`, which resolves to "not decided" and is immediately auto-enabled again on the next rebuild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
