### PR TITLE
Map the Robotic Vacuum Cleaner device type in both directions

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,8 @@ Tests are located in the `test/` directory and use ts-node for direct TypeScript
 ### **WORK IN PROGRESS**
 * (@Apollon77) Matter robotic vacuum cleaners are now mapped to the ioBroker vacuumCleaner device type in controller mode, including run mode, cleaning mode, operational state and phase, cleaning progress and the pause and go-home commands
 * (@Apollon77) ioBroker vacuum cleaners can now be exposed to Matter as a robotic vacuum cleaner in bridge and device mode, with the run mode, cleaning mode, operational state and the pause and go-home commands. The cleaning phase and progress are not exposed in this direction, because Matter reports them per cleaning area and an ioBroker vacuum cleaner does not know its areas
+* (@Apollon77) Fixed several ioBroker states of a controller device never updating after the first read, because two states reading one Matter attribute silently replaced each other. This affected the actual-value states of lights, plugs, dimmers, locks and speakers
+* (@Apollon77) Fixed the Device Manager rendering every enum and text state of a device as a number field
 * (@Apollon77) Sensors a Matter device exposes on child endpoints, such as the air quality, temperature and humidity of an air purifier, are now mapped as own ioBroker devices in controller mode
 * (@Apollon77) The raw Matter cluster data of such a child endpoint is now created below its own object only; the second copy below its parent, which was never updated again, is removed on the next start
 * (@Apollon77) Updated the type detector to v6, so the new device types it detects (air purifier, air quality, CO alarm, contact, electricity, fan, flow, pressure and pump) are recognized

--- a/README.md
+++ b/README.md
@@ -143,6 +143,8 @@ Tests are located in the `test/` directory and use ts-node for direct TypeScript
 
 ## Changelog
 ### **WORK IN PROGRESS**
+* (@Apollon77) Matter robotic vacuum cleaners are now mapped to the ioBroker vacuumCleaner device type in controller mode, including run mode, cleaning mode, operational state and phase, cleaning progress and the pause and go-home commands
+* (@Apollon77) ioBroker vacuum cleaners can now be exposed to Matter as a robotic vacuum cleaner in bridge and device mode, with the run mode, cleaning mode, operational state and the pause and go-home commands. The cleaning phase and progress are not exposed in this direction, because Matter reports them per cleaning area and an ioBroker vacuum cleaner does not know its areas
 * (@Apollon77) Sensors a Matter device exposes on child endpoints, such as the air quality, temperature and humidity of an air purifier, are now mapped as own ioBroker devices in controller mode
 * (@Apollon77) The raw Matter cluster data of such a child endpoint is now created below its own object only; the second copy below its parent, which was never updated again, is removed on the next start
 * (@Apollon77) Updated the type detector to v6, so the new device types it detects (air purifier, air quality, CO alarm, contact, electricity, fan, flow, pressure and pump) are recognized

--- a/src-admin/src/components/DeviceDialog.tsx
+++ b/src-admin/src/components/DeviceDialog.tsx
@@ -64,6 +64,7 @@ export const SUPPORTED_DEVICES: Types[] = [
     Types.socket,
     Types.temperature,
     Types.thermostat,
+    Types.vacuumCleaner,
     Types.volume,
     Types.volumeGroup,
     Types.window,

--- a/src/lib/devices/GenericDevice.ts
+++ b/src/lib/devices/GenericDevice.ts
@@ -64,7 +64,7 @@ export abstract class GenericDevice extends EventEmitter {
     #handlers = new Array<(event: { property: PropertyType; value: any; device: GenericDevice }) => Promise<void>>();
     protected _construction = new Array<() => Promise<void>>();
 
-    #errorState?: DeviceStateObject<boolean>;
+    #errorState?: DeviceStateObject<boolean | string>;
     #maintenanceState?: DeviceStateObject<boolean>;
     #unreachState?: DeviceStateObject<boolean>;
     #lowbatState?: DeviceStateObject<boolean>;
@@ -297,7 +297,7 @@ export abstract class GenericDevice extends EventEmitter {
                 // subscribe and read only if not already subscribed
                 if (stateId && !this.#subscribeObjects.find(obj => obj.state.id === stateId)) {
                     await object.subscribe(
-                        this.updateState,
+                        this.#handleIoBrokerStateChange,
                         this.#isIoBrokerDevice || this.#properties[type].accessType !== StateAccessType.Write,
                     );
                     this.#subscribeObjects.push(object);
@@ -401,14 +401,18 @@ export abstract class GenericDevice extends EventEmitter {
         return this.#deviceType;
     }
 
-    protected updateState = async <T>(object: DeviceStateObject<T>): Promise<void> => {
+    /**
+     * Named apart from the `update<Property>` methods, which {@link updatePropertyValue} resolves by name - an
+     * `updateState` here would shadow the one a device type declares for its STATE property.
+     */
+    #handleIoBrokerStateChange = async <T>(object: DeviceStateObject<T>): Promise<void> => {
         if (!this.enabled && object.propertyType !== PropertyType.Unreachable) {
             // When disabled, only report unreachable ioBroker changes to Matter
             return;
         }
         if (!this.#isIoBrokerDevice && this.#properties[object.propertyType].accessType === StateAccessType.Read) {
             this.#adapter.log.info(
-                `updateState not allowed for type ${object.propertyType} and value ${object.value as string}`,
+                `State change not allowed for type ${object.propertyType} and value ${object.value as string}`,
             );
             return;
         }
@@ -456,14 +460,14 @@ export abstract class GenericDevice extends EventEmitter {
         return result;
     }
 
-    getError(): boolean | number | undefined {
+    getError(): boolean | number | string | undefined {
         if (!this.#errorState) {
             throw new Error('Error state not found');
         }
         return this.#errorState.value;
     }
 
-    updateError(value: boolean): Promise<void> {
+    updateError(value: boolean | string): Promise<void> {
         if (!this.#errorState) {
             throw new Error('Error state not found');
         }

--- a/src/lib/devices/GenericDevice.ts
+++ b/src/lib/devices/GenericDevice.ts
@@ -101,7 +101,7 @@ export abstract class GenericDevice extends EventEmitter {
             this.addDeviceStates([
                 {
                     name: 'ERROR',
-                    valueType: ValueType.Boolean,
+                    valueType: ValueType.String,
                     accessType: StateAccessType.Read,
                     type: PropertyType.Error,
                     callback: state => (this.#errorState = state),
@@ -880,7 +880,11 @@ export abstract class GenericDevice extends EventEmitter {
             }
             return 'switch';
         }
-        if (valueType === ValueType.Number || valueType === ValueType.NumberPercent || ValueType.NumberMinMax) {
+        if (
+            valueType === ValueType.Number ||
+            valueType === ValueType.NumberPercent ||
+            valueType === ValueType.NumberMinMax
+        ) {
             if (hasMinMax) {
                 return 'slider';
             }

--- a/src/lib/devices/VacuumCleaner.ts
+++ b/src/lib/devices/VacuumCleaner.ts
@@ -1,7 +1,7 @@
 import { type DeviceStateObject, PropertyType, ValueType } from './DeviceStateObject';
 import { GenericDevice, type DetectedDevice, type DeviceOptions, StateAccessType } from './GenericDevice';
 
-enum VacuumCleanerMode {
+export enum VacuumCleanerMode {
     AUTO = 'AUTO',
     ECO = 'ECO',
     EXPRESS = 'EXPRESS',
@@ -17,10 +17,16 @@ enum VacuumCleanerWorkMode {
     TURBO = 'TURBO',
 }
 
-enum VacuumCleanerState {
+export enum VacuumCleanerState {
     HOME = 'HOME',
     CLEANING = 'CLEANING',
     PAUSE = 'PAUSE',
+}
+
+export enum VacuumCleanerStateNumbers {
+    HOME = 0,
+    CLEANING = 1,
+    PAUSE = 2,
 }
 
 export enum VacuumCleanerRunMode {
@@ -220,6 +226,10 @@ export class VacuumCleaner extends GenericDevice {
         return this.#powerState.updateValue(value);
     }
 
+    hasPower(): boolean {
+        return !!this.#powerState;
+    }
+
     getMode(): VacuumCleanerMode | undefined {
         if (!this.#modeState) {
             throw new Error('Mode state not found');
@@ -232,6 +242,13 @@ export class VacuumCleaner extends GenericDevice {
             throw new Error('Mode state not found');
         }
         return this.#modeState.setValue(mode);
+    }
+
+    updateMode(mode: VacuumCleanerMode): Promise<void> {
+        if (!this.#modeState) {
+            throw new Error('Mode state not found');
+        }
+        return this.#modeState.updateValue(mode);
     }
 
     getModes(): VacuumCleanerMode[] {
@@ -301,6 +318,13 @@ export class VacuumCleaner extends GenericDevice {
         return this.#getStateState.value;
     }
 
+    updateState(value: VacuumCleanerState): Promise<void> {
+        if (!this.#getStateState) {
+            throw new Error('State state not found');
+        }
+        return this.#getStateState.updateValue(value);
+    }
+
     getStateModes(): VacuumCleanerState[] {
         if (!this.#getStateState) {
             throw new Error('State state not found');
@@ -308,11 +332,19 @@ export class VacuumCleaner extends GenericDevice {
         return this.#getStateState.getModes();
     }
 
+    hasState(): boolean {
+        return !!this.#getStateState;
+    }
+
     setPause(value: boolean): Promise<void> {
         if (!this.#pauseState) {
             throw new Error('Pause state not found');
         }
         return this.#pauseState.setValue(value);
+    }
+
+    hasPause(): boolean {
+        return !!this.#pauseState;
     }
 
     getWasteAlarm(): boolean | undefined {
@@ -362,6 +394,10 @@ export class VacuumCleaner extends GenericDevice {
             throw new Error('Home state not found');
         }
         return this.#homeState.setValue(value);
+    }
+
+    hasHome(): boolean {
+        return !!this.#homeState;
     }
 
     getRunMode(): VacuumCleanerRunMode | undefined {

--- a/src/matter/behaviors/EventedRvcServers.ts
+++ b/src/matter/behaviors/EventedRvcServers.ts
@@ -1,0 +1,106 @@
+import { AsyncObservable, MaybePromise } from '@matter/main';
+import {
+    OperationalStateUtils,
+    RvcCleanModeServer,
+    RvcOperationalStateServer,
+    RvcRunModeServer,
+} from '@matter/main/behaviors';
+import { ModeBase, OperationalState, type RvcOperationalState } from '@matter/main/clusters';
+
+/**
+ * The events are awaited, so a command response only goes out once the ioBroker side has taken the change. Matter
+ * derives the accepted command list from the methods a behavior implements, so a robot that cannot be paused or sent
+ * home must be served by a class that does not carry the method at all.
+ */
+export class IoRvcOperationalStateServer extends RvcOperationalStateServer {
+    declare events: IoRvcOperationalStateServer.Events;
+
+    protected emitAndRespond(
+        result: OperationalState.OperationalCommandResponse,
+        emit: (events: IoRvcOperationalStateServer.Events) => MaybePromise<void> | undefined,
+    ): MaybePromise<OperationalState.OperationalCommandResponse> {
+        if (result.commandResponseState.errorStateId !== OperationalState.ErrorState.NoError) {
+            return result;
+        }
+        return MaybePromise.then(emit(this.events), () => result);
+    }
+
+    protected triggerGoHome(): MaybePromise<RvcOperationalState.OperationalCommandResponse> {
+        return this.emitAndRespond(OperationalStateUtils.assertRvcGoHome(this.state.operationalState), events =>
+            events.rvcGoHomeTriggered.emit(),
+        );
+    }
+}
+
+// eslint-disable-next-line @typescript-eslint/no-namespace
+export namespace IoRvcOperationalStateServer {
+    export class Events extends RvcOperationalStateServer.Events {
+        rvcPauseTriggered = AsyncObservable();
+        rvcResumeTriggered = AsyncObservable();
+        rvcGoHomeTriggered = AsyncObservable();
+    }
+}
+
+export class IoRvcOperationalStateServerWithPause extends IoRvcOperationalStateServer {
+    override pause(): MaybePromise<RvcOperationalState.OperationalCommandResponse> {
+        return this.emitAndRespond(OperationalStateUtils.assertRvcPause(this.state.operationalState), events =>
+            events.rvcPauseTriggered.emit(),
+        );
+    }
+
+    override resume(): MaybePromise<RvcOperationalState.OperationalCommandResponse> {
+        return this.emitAndRespond(OperationalStateUtils.assertRvcResume(this.state.operationalState), events =>
+            events.rvcResumeTriggered.emit(),
+        );
+    }
+}
+
+export class IoRvcOperationalStateServerWithGoHome extends IoRvcOperationalStateServer {
+    override goHome(): MaybePromise<RvcOperationalState.OperationalCommandResponse> {
+        return this.triggerGoHome();
+    }
+}
+
+export class IoRvcOperationalStateServerWithPauseAndGoHome extends IoRvcOperationalStateServerWithPause {
+    override goHome(): MaybePromise<RvcOperationalState.OperationalCommandResponse> {
+        return this.triggerGoHome();
+    }
+}
+
+export class IoRvcRunModeServer extends RvcRunModeServer {
+    declare events: IoRvcRunModeServer.Events;
+
+    override changeToMode(request: ModeBase.ChangeToModeRequest): MaybePromise<ModeBase.ChangeToModeResponse> {
+        return MaybePromise.then(super.changeToMode(request), result =>
+            result.status === ModeBase.ModeChangeStatus.Success
+                ? MaybePromise.then(this.events.rvcRunModeControlled.emit(request.newMode), () => result)
+                : result,
+        );
+    }
+}
+
+// eslint-disable-next-line @typescript-eslint/no-namespace
+export namespace IoRvcRunModeServer {
+    export class Events extends RvcRunModeServer.Events {
+        rvcRunModeControlled = AsyncObservable<[mode: number]>();
+    }
+}
+
+export class IoRvcCleanModeServer extends RvcCleanModeServer {
+    declare events: IoRvcCleanModeServer.Events;
+
+    override changeToMode(request: ModeBase.ChangeToModeRequest): MaybePromise<ModeBase.ChangeToModeResponse> {
+        return MaybePromise.then(super.changeToMode(request), result =>
+            result.status === ModeBase.ModeChangeStatus.Success
+                ? MaybePromise.then(this.events.rvcCleanModeControlled.emit(request.newMode), () => result)
+                : result,
+        );
+    }
+}
+
+// eslint-disable-next-line @typescript-eslint/no-namespace
+export namespace IoRvcCleanModeServer {
+    export class Events extends RvcCleanModeServer.Events {
+        rvcCleanModeControlled = AsyncObservable<[mode: number]>();
+    }
+}

--- a/src/matter/to-iobroker/AirPurifierToIoBroker.ts
+++ b/src/matter/to-iobroker/AirPurifierToIoBroker.ts
@@ -60,18 +60,6 @@ export class AirPurifierToIoBroker extends FanToIoBroker {
             convertValue: (value: ResourceMonitoring.ChangeIndication) =>
                 changeIndicated(value) || hepaChangeIndicated(this.appEndpoint),
         });
-        // A property binds to one cluster only, so the carbon filter needs its own path into the same state
-        this.registerStateChangeHandlerForAttribute({
-            endpointId,
-            clusterId: ActivatedCarbonFilterMonitoring.id,
-            attributeName: 'changeIndication',
-            matterValueChanged: (value: ResourceMonitoring.ChangeIndication) =>
-                this.ioBrokerDevice.updatePropertyValue(
-                    PropertyType.FilterChange,
-                    changeIndicated(value) || hepaChangeIndicated(this.appEndpoint),
-                ),
-        });
-
         return super.enableDeviceTypeStates();
     }
 }

--- a/src/matter/to-iobroker/AirPurifierToIoBroker.ts
+++ b/src/matter/to-iobroker/AirPurifierToIoBroker.ts
@@ -53,13 +53,18 @@ export class AirPurifierToIoBroker extends FanToIoBroker {
             convertValue: (value: ResourceMonitoring.ChangeIndication) =>
                 changeIndicated(value) || carbonChangeIndicated(this.appEndpoint),
         });
-        this.enableDeviceTypeStateForAttribute(PropertyType.FilterChange, {
+        // A property is enabled once, so the second attribute feeding the same state needs a handler of its own
+        this.registerStateChangeHandlerForAttribute({
             endpointId,
             clusterId: ActivatedCarbonFilterMonitoring.id,
             attributeName: 'changeIndication',
-            convertValue: (value: ResourceMonitoring.ChangeIndication) =>
-                changeIndicated(value) || hepaChangeIndicated(this.appEndpoint),
+            matterValueChanged: (value: ResourceMonitoring.ChangeIndication) =>
+                this.ioBrokerDevice.updatePropertyValue(
+                    PropertyType.FilterChange,
+                    changeIndicated(value) || hepaChangeIndicated(this.appEndpoint),
+                ),
         });
+
         return super.enableDeviceTypeStates();
     }
 }

--- a/src/matter/to-iobroker/AirPurifierToIoBroker.ts
+++ b/src/matter/to-iobroker/AirPurifierToIoBroker.ts
@@ -46,24 +46,22 @@ export class AirPurifierToIoBroker extends FanToIoBroker {
 
         // The ioBroker device has one maintenance flag for all filters, so either monitoring cluster raises it. The
         // cluster that did not change is read from the endpoint state, where it still holds its current value.
-        this.enableDeviceTypeStateForAttribute(PropertyType.FilterChange, {
-            endpointId,
-            clusterId: HepaFilterMonitoring.id,
-            attributeName: 'changeIndication',
-            convertValue: (value: ResourceMonitoring.ChangeIndication) =>
-                changeIndicated(value) || carbonChangeIndicated(this.appEndpoint),
-        });
-        // A property is enabled once, so the second attribute feeding the same state needs a handler of its own
-        this.registerStateChangeHandlerForAttribute({
-            endpointId,
-            clusterId: ActivatedCarbonFilterMonitoring.id,
-            attributeName: 'changeIndication',
-            matterValueChanged: (value: ResourceMonitoring.ChangeIndication) =>
-                this.ioBrokerDevice.updatePropertyValue(
-                    PropertyType.FilterChange,
+        this.enableDeviceTypeStateForAttributes(PropertyType.FilterChange, [
+            {
+                endpointId,
+                clusterId: HepaFilterMonitoring.id,
+                attributeName: 'changeIndication',
+                convertValue: (value: ResourceMonitoring.ChangeIndication) =>
+                    changeIndicated(value) || carbonChangeIndicated(this.appEndpoint),
+            },
+            {
+                endpointId,
+                clusterId: ActivatedCarbonFilterMonitoring.id,
+                attributeName: 'changeIndication',
+                convertValue: (value: ResourceMonitoring.ChangeIndication) =>
                     changeIndicated(value) || hepaChangeIndicated(this.appEndpoint),
-                ),
-        });
+            },
+        ]);
 
         return super.enableDeviceTypeStates();
     }

--- a/src/matter/to-iobroker/ColorTemperatureLightToIoBroker.ts
+++ b/src/matter/to-iobroker/ColorTemperatureLightToIoBroker.ts
@@ -108,10 +108,6 @@ export class ColorTemperatureLightToIoBroker extends GenericElectricityDataDevic
             endpointId: this.appEndpoint.number,
             clusterId: OnOff.id,
             attributeName: 'onOff',
-            convertValue: async value => {
-                await this.#ioBrokerDevice.updatePower(value); // Also Ack Power Set State
-                return value;
-            },
         });
 
         this.enableDeviceTypeStateForAttribute(PropertyType.Dimmer, {

--- a/src/matter/to-iobroker/DimmableToIoBroker.ts
+++ b/src/matter/to-iobroker/DimmableToIoBroker.ts
@@ -89,10 +89,6 @@ export class DimmableToIoBroker extends GenericElectricityDataDeviceToIoBroker<D
             endpointId: this.appEndpoint.number,
             clusterId: OnOff.id,
             attributeName: 'onOff',
-            convertValue: async value => {
-                await this.#ioBrokerDevice.updatePower(value); // Also Ack Power Set State
-                return value;
-            },
         });
         this.enableDeviceTypeStateForAttribute(PropertyType.Level, {
             endpointId: this.appEndpoint.number,

--- a/src/matter/to-iobroker/ExtendedColorLightToIoBroker.ts
+++ b/src/matter/to-iobroker/ExtendedColorLightToIoBroker.ts
@@ -240,10 +240,6 @@ export class ExtendedColorLightToIoBroker extends GenericElectricityDataDeviceTo
             endpointId: this.appEndpoint.number,
             clusterId: OnOff.id,
             attributeName: 'onOff',
-            convertValue: async value => {
-                await this.#ioBrokerDevice.updatePower(value); // Also Ack Power Set State
-                return value;
-            },
         });
 
         this.enableDeviceTypeStateForAttribute(PropertyType.Dimmer, {

--- a/src/matter/to-iobroker/GenericDeviceToIoBroker.ts
+++ b/src/matter/to-iobroker/GenericDeviceToIoBroker.ts
@@ -255,6 +255,46 @@ export abstract class GenericDeviceToIoBroker<C extends CustomStatesRecord = Emp
         }
     }
 
+    /**
+     * Enable a state that the device type derives from several Matter attributes, such as a maintenance flag that two
+     * monitoring clusters both raise.
+     *
+     * Each source converts on its own, because the attribute that changed has to be combined with the attributes that
+     * did not. The first supported source owns the state, and every further one reaches it through a handler, because
+     * a property is enabled once and the later registration would otherwise be dropped.
+     */
+    protected enableDeviceTypeStateForAttributes(
+        type: PropertyType,
+        sources: {
+            endpointId: EndpointNumber;
+            clusterId: ClusterId;
+            attributeName: string;
+            convertValue: (value: any) => MaybePromise<any>;
+        }[],
+    ): void {
+        let owned = false;
+        for (const source of sources) {
+            if (!owned) {
+                this.enableDeviceTypeStateForAttribute(type, source);
+                owned = this.#enabledAttributeProperties.has(type);
+                if (owned) {
+                    continue;
+                }
+            }
+            this.registerStateChangeHandlerForAttribute({
+                endpointId: source.endpointId,
+                clusterId: source.clusterId,
+                attributeName: source.attributeName,
+                matterValueChanged: async value => {
+                    const converted = await source.convertValue(value);
+                    if (converted !== undefined) {
+                        await this.ioBrokerDevice.updatePropertyValue(type, converted);
+                    }
+                },
+            });
+        }
+    }
+
     protected registerStateChangeHandlerForAttribute(
         data: {
             endpointId: EndpointNumber;

--- a/src/matter/to-iobroker/GenericDeviceToIoBroker.ts
+++ b/src/matter/to-iobroker/GenericDeviceToIoBroker.ts
@@ -100,7 +100,11 @@ export abstract class GenericDeviceToIoBroker<C extends CustomStatesRecord = Emp
     readonly #deviceOptions: DeviceOptions;
     #enabledAttributeProperties = new Map<PropertyType, EnabledAttributeProperty>();
     #enabledEventProperties = new Map<PropertyType, EnabledEventProperty[]>();
-    #matterMappings = new Map<string, PropertyType | ((value: any) => MaybePromise<any>)>();
+    /**
+     * Several properties may read one Matter attribute - an X and its X_ACTUAL, or a device type deriving two of its
+     * states from one value - so a path carries every mapping registered for it, in registration order.
+     */
+    #matterMappings = new Map<string, (PropertyType | ((value: any) => MaybePromise<any>))[]>();
     #connectionStateId: string;
     #hasBridgedReachabilityAttribute = false;
     #pollTimeout?: ioBroker.Timeout;
@@ -273,8 +277,16 @@ export abstract class GenericDeviceToIoBroker<C extends CustomStatesRecord = Emp
             );
             return;
         }
-        const pathId = attributePathToString({ endpointId, clusterId, attributeName });
-        this.#matterMappings.set(pathId, matterValueChanged);
+        this.#addMatterMapping(attributePathToString({ endpointId, clusterId, attributeName }), matterValueChanged);
+    }
+
+    #addMatterMapping(pathId: string, mapping: PropertyType | ((value: any) => MaybePromise<any>)): void {
+        const mappings = this.#matterMappings.get(pathId);
+        if (mappings === undefined) {
+            this.#matterMappings.set(pathId, [mapping]);
+        } else {
+            mappings.push(mapping);
+        }
     }
 
     /**
@@ -321,8 +333,7 @@ export abstract class GenericDeviceToIoBroker<C extends CustomStatesRecord = Emp
             }
 
             if (endpointId !== undefined && clusterId !== undefined && attributeName !== undefined) {
-                const pathId = attributePathToString({ endpointId, clusterId, attributeName });
-                this.#matterMappings.set(pathId, type);
+                this.#addMatterMapping(attributePathToString({ endpointId, clusterId, attributeName }), type);
             }
             this.#enabledAttributeProperties.set(type, {
                 type: 'attribute',
@@ -376,12 +387,8 @@ export abstract class GenericDeviceToIoBroker<C extends CustomStatesRecord = Emp
         if (stateData.id === undefined) {
             stateData.id = `${this.baseId}.`;
         }
-        const pathId = eventPathToString({ endpointId, clusterId, eventName });
         this.#deviceOptions.additionalStateData![type] = stateData;
-        if (this.#matterMappings.get(pathId)) {
-            this.#adapter.log.warn(`State path ${pathId} already enabled, overwriting`);
-        }
-        this.#matterMappings.set(pathId, type);
+        this.#addMatterMapping(eventPathToString({ endpointId, clusterId, eventName }), type);
         const knownEvents = this.#enabledEventProperties.get(type) ?? [];
         knownEvents.push({
             type: 'event',
@@ -557,13 +564,15 @@ export abstract class GenericDeviceToIoBroker<C extends CustomStatesRecord = Emp
         const pathId = attributePathToString(data);
 
         // Check standard property mappings first
-        const pathProperty = this.#matterMappings.get(pathId);
-        if (pathProperty !== undefined) {
-            if (typeof pathProperty === 'function') {
-                await pathProperty(data.value);
-                return;
+        const pathProperties = this.#matterMappings.get(pathId);
+        if (pathProperties !== undefined) {
+            for (const pathProperty of pathProperties) {
+                if (typeof pathProperty === 'function') {
+                    await pathProperty(data.value);
+                } else {
+                    await this.updateIoBrokerState(pathProperty, data.value);
+                }
             }
-            await this.updateIoBrokerState(pathProperty, data.value);
             return;
         }
 
@@ -586,28 +595,32 @@ export abstract class GenericDeviceToIoBroker<C extends CustomStatesRecord = Emp
         events: DecodedEventData<any>[];
     }): Promise<void> {
         const pathId = eventPathToString(data);
-        const pathProperty = this.#matterMappings.get(pathId);
-        if (pathProperty === undefined) {
+        const pathProperties = this.#matterMappings.get(pathId);
+        if (pathProperties === undefined) {
             return;
         }
-        if (typeof pathProperty === 'function') {
-            for (const event of data.events) {
-                await pathProperty(event);
+        for (const pathProperty of pathProperties) {
+            if (typeof pathProperty === 'function') {
+                for (const event of data.events) {
+                    await pathProperty(event);
+                }
+                continue;
             }
-            return;
-        }
-        const propertyHandlers = this.#enabledEventProperties.get(pathProperty);
-        if (propertyHandlers === undefined) {
-            return;
-        }
-        for (const { convertValue } of propertyHandlers) {
-            for (const event of data.events) {
-                const value = await convertValue(pathProperty, event);
-                if (value !== undefined) {
-                    try {
-                        await this.ioBrokerDevice.updatePropertyValue(pathProperty, value);
-                    } catch (e) {
-                        this.#adapter.log.error(`Error updating property ${pathProperty} with value ${value}: ${e}`);
+            const propertyHandlers = this.#enabledEventProperties.get(pathProperty);
+            if (propertyHandlers === undefined) {
+                continue;
+            }
+            for (const { convertValue } of propertyHandlers) {
+                for (const event of data.events) {
+                    const value = await convertValue(pathProperty, event);
+                    if (value !== undefined) {
+                        try {
+                            await this.ioBrokerDevice.updatePropertyValue(pathProperty, value);
+                        } catch (e) {
+                            this.#adapter.log.error(
+                                `Error updating property ${pathProperty} with value ${value}: ${e}`,
+                            );
+                        }
                     }
                 }
             }

--- a/src/matter/to-iobroker/OnOffLightToIoBroker.ts
+++ b/src/matter/to-iobroker/OnOffLightToIoBroker.ts
@@ -62,10 +62,6 @@ export class OnOffLightToIoBroker extends GenericElectricityDataDeviceToIoBroker
             endpointId: this.appEndpoint.number,
             clusterId: OnOff.id,
             attributeName: 'onOff',
-            convertValue: async value => {
-                await this.#ioBrokerDevice.updatePower(value); // Also Ack Power Set State
-                return value;
-            },
         });
         return super.enableDeviceTypeStates();
     }

--- a/src/matter/to-iobroker/OnOffPlugInUnitToIoBroker.ts
+++ b/src/matter/to-iobroker/OnOffPlugInUnitToIoBroker.ts
@@ -62,10 +62,6 @@ export class OnOffPlugInUnitToIoBroker extends GenericElectricityDataDeviceToIoB
             endpointId: this.appEndpoint.number,
             clusterId: OnOff.id,
             attributeName: 'onOff',
-            convertValue: async value => {
-                await this.#ioBrokerDevice.updatePower(value); // Also Ack Power Set State
-                return value;
-            },
         });
         return super.enableDeviceTypeStates();
     }

--- a/src/matter/to-iobroker/RoboticVacuumCleanerToIoBroker.ts
+++ b/src/matter/to-iobroker/RoboticVacuumCleanerToIoBroker.ts
@@ -1,0 +1,363 @@
+import ChannelDetector from '@iobroker/type-detector';
+import type { Endpoint } from '@matter/main';
+import {
+    ModeBase,
+    OperationalState,
+    RvcCleanMode,
+    RvcOperationalState,
+    RvcRunMode,
+    ServiceArea,
+} from '@matter/main/clusters';
+import { RvcCleanModeClient, RvcOperationalStateClient, RvcRunModeClient } from '@matter/main/behaviors';
+import type { PairedNode } from '@project-chip/matter.js/device';
+import { PropertyType } from '../../lib/devices/DeviceStateObject';
+import type { DetectedDevice, DeviceOptions } from '../../lib/devices/GenericDevice';
+import {
+    VacuumCleaner,
+    VacuumCleanerRunMode,
+    VacuumCleanerRunModeNumbers,
+    VacuumCleanerState,
+    VacuumCleanerStateNumbers,
+} from '../../lib/devices/VacuumCleaner';
+import { GenericDeviceToIoBroker } from './GenericDeviceToIoBroker';
+import type { MatterAdapter } from '../../main';
+
+type ModeOption = {
+    readonly label: string;
+    readonly mode: number;
+    readonly modeTags: readonly { readonly value: number }[];
+};
+
+const RUN_MODE_BY_TAG = new Map<number, VacuumCleanerRunMode>([
+    [RvcRunMode.ModeTag.Idle, VacuumCleanerRunMode.Idle],
+    [RvcRunMode.ModeTag.Cleaning, VacuumCleanerRunMode.Cleaning],
+    [RvcRunMode.ModeTag.Mapping, VacuumCleanerRunMode.Mapping],
+]);
+
+const RUN_MODE_KEYS: Record<VacuumCleanerRunMode, number> = {
+    [VacuumCleanerRunMode.Idle]: VacuumCleanerRunModeNumbers.IDLE,
+    [VacuumCleanerRunMode.Cleaning]: VacuumCleanerRunModeNumbers.CLEANING,
+    [VacuumCleanerRunMode.Mapping]: VacuumCleanerRunModeNumbers.MAPPING,
+};
+
+/**
+ * The three ioBroker states a robot can report. Matter names more, and each of them is either the robot working, the
+ * robot halted, or one of the many ways of being at the dock, which is as much as the ioBroker state can express.
+ */
+const STATE_BY_OPERATIONAL_STATE = new Map<number, VacuumCleanerState>([
+    [RvcOperationalState.OperationalState.Running, VacuumCleanerState.CLEANING],
+    [RvcOperationalState.OperationalState.Paused, VacuumCleanerState.PAUSE],
+    [RvcOperationalState.OperationalState.Stopped, VacuumCleanerState.PAUSE],
+    [RvcOperationalState.OperationalState.SeekingCharger, VacuumCleanerState.HOME],
+    [RvcOperationalState.OperationalState.Charging, VacuumCleanerState.HOME],
+    [RvcOperationalState.OperationalState.Docked, VacuumCleanerState.HOME],
+    [RvcOperationalState.OperationalState.EmptyingDustBin, VacuumCleanerState.HOME],
+    [RvcOperationalState.OperationalState.CleaningMop, VacuumCleanerState.HOME],
+    [RvcOperationalState.OperationalState.FillingWaterTank, VacuumCleanerState.HOME],
+    [RvcOperationalState.OperationalState.UpdatingMaps, VacuumCleanerState.HOME],
+]);
+
+/** Turns a vendor mode label into an ioBroker enum value, which may not contain the separators a label can. */
+function modeLabelToEnumValue(label: string, mode: number): string {
+    const value = label
+        .trim()
+        .toUpperCase()
+        .replace(/[^A-Z0-9]+/g, '_')
+        .replace(/^_+|_+$/g, '');
+    return value.length > 0 ? value : `MODE_${mode}`;
+}
+
+export class RoboticVacuumCleanerToIoBroker extends GenericDeviceToIoBroker {
+    readonly #adapter: MatterAdapter;
+    readonly #ioBrokerDevice: VacuumCleaner;
+
+    constructor(
+        node: PairedNode,
+        endpoint: Endpoint,
+        rootEndpoint: Endpoint,
+        adapter: MatterAdapter,
+        endpointDeviceBaseId: string,
+        deviceTypeName: string,
+        defaultConnectionStateId: string,
+        defaultName: string,
+    ) {
+        super(
+            adapter,
+            node,
+            endpoint,
+            rootEndpoint,
+            endpointDeviceBaseId,
+            deviceTypeName,
+            defaultConnectionStateId,
+            defaultName,
+        );
+
+        this.#adapter = adapter;
+        this.#ioBrokerDevice = new VacuumCleaner(
+            { ...ChannelDetector.getPatterns().vacuumCleaner, isIoBrokerDevice: false } as DetectedDevice,
+            adapter,
+            this.enableDeviceTypeStates(),
+        );
+    }
+
+    #runModeOptions(): readonly ModeOption[] {
+        return this.appEndpoint.maybeStateOf(RvcRunModeClient)?.supportedModes ?? [];
+    }
+
+    #cleanModeOptions(): readonly ModeOption[] {
+        return this.appEndpoint.maybeStateOf(RvcCleanModeClient)?.supportedModes ?? [];
+    }
+
+    /** The ioBroker run mode a Matter mode stands for, taken from its tags because the mode numbers are vendor defined. */
+    #runModeOf(mode: number | undefined): VacuumCleanerRunMode | undefined {
+        if (mode === undefined) {
+            return undefined;
+        }
+        const option = this.#runModeOptions().find(({ mode: supported }) => supported === mode);
+        for (const { value } of option?.modeTags ?? []) {
+            const runMode = RUN_MODE_BY_TAG.get(value);
+            if (runMode !== undefined) {
+                return runMode;
+            }
+        }
+        return undefined;
+    }
+
+    /** The first Matter mode carrying the tag for an ioBroker run mode. A robot may offer several cleaning modes. */
+    #matterRunModeFor(runMode: VacuumCleanerRunMode): number | undefined {
+        for (const option of this.#runModeOptions()) {
+            for (const { value } of option.modeTags ?? []) {
+                if (RUN_MODE_BY_TAG.get(value) === runMode) {
+                    return option.mode;
+                }
+            }
+        }
+        return undefined;
+    }
+
+    #runModes(): { [key: number]: VacuumCleanerRunMode } {
+        const modes: { [key: number]: VacuumCleanerRunMode } = {};
+        for (const option of this.#runModeOptions()) {
+            const runMode = this.#runModeOf(option.mode);
+            if (runMode !== undefined) {
+                modes[RUN_MODE_KEYS[runMode]] = runMode;
+            }
+        }
+        return modes;
+    }
+
+    async #changeRunMode(runMode: VacuumCleanerRunMode): Promise<void> {
+        const newMode = this.#matterRunModeFor(runMode);
+        if (newMode === undefined) {
+            this.#adapter.log.info(`${this.baseId}: Device offers no ${runMode} run mode`);
+            return;
+        }
+        const response = await this.appEndpoint.commandsOf(RvcRunModeClient)?.changeToMode({ newMode });
+        if (response !== undefined && response.status !== ModeBase.ModeChangeStatus.Success) {
+            this.#adapter.log.info(
+                `${this.baseId}: Device rejected run mode ${runMode}: ${response.statusText ?? response.status}`,
+            );
+        }
+    }
+
+    /** Pause, Resume and GoHome are optional, so only a robot that accepts them can be driven with them. */
+    #acceptsCommands(...commandNames: string[]): boolean {
+        if (!this.appEndpoint.behaviors.has(RvcOperationalStateClient)) {
+            return false;
+        }
+        let commands: ReadonlySet<string>;
+        try {
+            commands = this.appEndpoint.behaviors.elementsOf(RvcOperationalStateClient).commands;
+        } catch (error) {
+            // Reading the element list this early throws while the behavior is still initializing
+            this.#adapter.log.info(`${this.baseId}: Cannot read the accepted commands of the robot: ${error}`);
+            return false;
+        }
+        return commandNames.every(name => commands.has(name));
+    }
+
+    /** Idle is the robot doing nothing, which is what POWER off means for a device type that has no OnOff cluster. */
+    #powerOf(mode: number): boolean | undefined {
+        const runMode = this.#runModeOf(mode);
+        return runMode === undefined ? undefined : runMode !== VacuumCleanerRunMode.Idle;
+    }
+
+    /** An empty phase says the robot is in no phase, which a stale phase name would misreport. */
+    #phaseOf(currentPhase: number | null | undefined): string {
+        if (currentPhase === null || currentPhase === undefined) {
+            return '';
+        }
+        return this.appEndpoint.maybeStateOf(RvcOperationalStateClient)?.phaseList?.[currentPhase] ?? '';
+    }
+
+    /**
+     * Matter reports a per-area status list rather than a percentage, so the share of areas the robot is done with is
+     * the only percentage the cluster backs. Skipped areas count as done because the robot will not return to them.
+     */
+    #progressOf(progress: ServiceArea.Progress[] | undefined): number | undefined {
+        if (!Array.isArray(progress) || progress.length === 0) {
+            return undefined;
+        }
+        const finished = progress.filter(
+            ({ status }) =>
+                status === ServiceArea.OperationalStatus.Completed || status === ServiceArea.OperationalStatus.Skipped,
+        ).length;
+        return Math.round((finished / progress.length) * 100);
+    }
+
+    protected enableDeviceTypeStates(): DeviceOptions {
+        const endpointId = this.appEndpoint.number;
+
+        // A robotic vacuum cleaner has no OnOff cluster, and the ioBroker device type requires POWER, so the run mode
+        // is what backs it: idle is off, and any other run mode is the robot doing something.
+        this.enableDeviceTypeStateForAttribute(PropertyType.Power, {
+            endpointId,
+            clusterId: RvcRunMode.id,
+            attributeName: 'currentMode',
+            convertValue: (value: number) => this.#powerOf(value),
+            changeHandler: async (value: boolean) =>
+                this.#changeRunMode(value ? VacuumCleanerRunMode.Cleaning : VacuumCleanerRunMode.Idle),
+        });
+
+        // Only one property may be mapped to an attribute path, and the one registered last wins it, so POWER is
+        // updated from here rather than from its own registration - which then only serves the initial read.
+        this.enableDeviceTypeStateForAttribute(PropertyType.RunMode, {
+            endpointId,
+            clusterId: RvcRunMode.id,
+            attributeName: 'currentMode',
+            modes: this.#runModes(),
+            convertValue: async (value: number) => {
+                const power = this.#powerOf(value);
+                if (power !== undefined) {
+                    await this.ioBrokerDevice.updatePower(power);
+                }
+                return this.#runModeOf(value);
+            },
+            changeHandler: async (value: VacuumCleanerRunMode) => this.#changeRunMode(value),
+        });
+
+        // RvcCleanMode modes are vendor defined and its tags (Vacuum, Mop, DeepClean) have no ioBroker counterpart,
+        // so the device's own labels are the only faithful values to offer.
+        const cleanModes: { [key: number]: string } = {};
+        const usedCleanModeValues = new Set<string>();
+        for (const option of this.#cleanModeOptions()) {
+            // Two labels can normalize to the same value, and the reverse lookup a write does needs them distinct
+            let value = modeLabelToEnumValue(option.label, option.mode);
+            if (usedCleanModeValues.has(value)) {
+                value = `${value}_${option.mode}`;
+            }
+            usedCleanModeValues.add(value);
+            cleanModes[option.mode] = value;
+        }
+        this.enableDeviceTypeStateForAttribute(PropertyType.Mode, {
+            endpointId,
+            clusterId: RvcCleanMode.id,
+            attributeName: 'currentMode',
+            modes: cleanModes,
+            convertValue: (value: number) => cleanModes[value],
+            changeHandler: async (value: string) => {
+                const newMode = Number(
+                    Object.keys(cleanModes).find(mode => cleanModes[Number(mode)] === value) ?? Number.NaN,
+                );
+                if (Number.isNaN(newMode)) {
+                    this.#adapter.log.info(`${this.baseId}: Device offers no ${value} clean mode`);
+                    return;
+                }
+                const response = await this.appEndpoint.commandsOf(RvcCleanModeClient)?.changeToMode({ newMode });
+                if (response !== undefined && response.status !== ModeBase.ModeChangeStatus.Success) {
+                    this.#adapter.log.info(
+                        `${this.baseId}: Device rejected clean mode ${value}: ${response.statusText ?? response.status}`,
+                    );
+                }
+            },
+        });
+
+        this.enableDeviceTypeStateForAttribute(PropertyType.State, {
+            endpointId,
+            clusterId: RvcOperationalState.id,
+            attributeName: 'operationalState',
+            modes: {
+                [VacuumCleanerStateNumbers.HOME]: VacuumCleanerState.HOME,
+                [VacuumCleanerStateNumbers.CLEANING]: VacuumCleanerState.CLEANING,
+                [VacuumCleanerStateNumbers.PAUSE]: VacuumCleanerState.PAUSE,
+            },
+            // Error has no ioBroker counterpart here; it surfaces through ERROR, and STATE keeps what it last knew
+            convertValue: (value: number) => STATE_BY_OPERATIONAL_STATE.get(value),
+        });
+
+        // The detector types ERROR as a string, so the robot's own error name says more than a raised flag would
+        this.enableDeviceTypeStateForAttribute(PropertyType.Error, {
+            endpointId,
+            clusterId: RvcOperationalState.id,
+            attributeName: 'operationalError',
+            convertValue: (value: RvcOperationalState.ErrorStateStruct) => {
+                const errorStateId = value?.errorStateId;
+                if (errorStateId === undefined || errorStateId === OperationalState.ErrorState.NoError) {
+                    return '';
+                }
+                return value.errorStateLabel ?? RvcOperationalState.ErrorState[errorStateId] ?? String(errorStateId);
+            },
+        });
+
+        this.enableDeviceTypeStateForAttribute(PropertyType.Phase, {
+            endpointId,
+            clusterId: RvcOperationalState.id,
+            attributeName: 'currentPhase',
+            convertValue: (value: number | null) => this.#phaseOf(value),
+        });
+        // The phase name comes from phaseList, so replacing that list renames the phase the robot is in
+        this.registerStateChangeHandlerForAttribute({
+            endpointId,
+            clusterId: RvcOperationalState.id,
+            attributeName: 'phaseList',
+            matterValueChanged: () =>
+                this.updateIoBrokerState(
+                    PropertyType.Phase,
+                    this.appEndpoint.maybeStateOf(RvcOperationalStateClient)?.currentPhase,
+                ),
+        });
+
+        this.enableDeviceTypeStateForAttribute(PropertyType.Progress, {
+            endpointId,
+            clusterId: ServiceArea.id,
+            attributeName: 'progress',
+            convertValue: (value: ServiceArea.Progress[]) => this.#progressOf(value),
+        });
+
+        // Pause and GoHome are commands, so they have no attribute to bind to and no value to read back
+        if (this.#acceptsCommands('pause', 'resume')) {
+            this.enableDeviceTypeStateForAttribute(PropertyType.Pause, {
+                changeHandler: async (value: boolean) => {
+                    const commands = this.appEndpoint.commandsOf(RvcOperationalStateClient);
+                    const response = value ? await commands?.pause() : await commands?.resume();
+                    const errorStateId = response?.commandResponseState?.errorStateId;
+                    if (errorStateId !== undefined && errorStateId !== OperationalState.ErrorState.NoError) {
+                        this.#adapter.log.info(
+                            `${this.baseId}: Device rejected ${value ? 'pause' : 'resume'}: ${errorStateId}`,
+                        );
+                    }
+                },
+            });
+        }
+        if (this.#acceptsCommands('goHome')) {
+            this.enableDeviceTypeStateForAttribute(PropertyType.Home, {
+                changeHandler: async (value: boolean) => {
+                    if (!value) {
+                        return;
+                    }
+                    const response = await this.appEndpoint.commandsOf(RvcOperationalStateClient)?.goHome();
+                    const errorStateId = response?.commandResponseState?.errorStateId;
+                    if (errorStateId !== undefined && errorStateId !== OperationalState.ErrorState.NoError) {
+                        this.#adapter.log.info(`${this.baseId}: Device rejected go home: ${errorStateId}`);
+                    }
+                },
+            });
+        }
+
+        return super.enableDeviceTypeStates();
+    }
+
+    get ioBrokerDevice(): VacuumCleaner {
+        return this.#ioBrokerDevice;
+    }
+}

--- a/src/matter/to-iobroker/RoboticVacuumCleanerToIoBroker.ts
+++ b/src/matter/to-iobroker/RoboticVacuumCleanerToIoBroker.ts
@@ -67,6 +67,21 @@ function modeLabelToEnumValue(label: string, mode: number): string {
     return value.length > 0 ? value : `MODE_${mode}`;
 }
 
+/**
+ * A suffixed form of a value that is not taken yet. The suffix keeps counting because a suffixed form can itself
+ * collide with the normalized form of another mode label.
+ */
+function uniqueEnumValue(value: string, taken: ReadonlySet<string>): string {
+    if (!taken.has(value)) {
+        return value;
+    }
+    let discriminator = 2;
+    while (taken.has(`${value}_${discriminator}`)) {
+        discriminator++;
+    }
+    return `${value}_${discriminator}`;
+}
+
 export class RoboticVacuumCleanerToIoBroker extends GenericDeviceToIoBroker {
     readonly #adapter: MatterAdapter;
     readonly #ioBrokerDevice: VacuumCleaner;
@@ -219,20 +234,12 @@ export class RoboticVacuumCleanerToIoBroker extends GenericDeviceToIoBroker {
                 this.#changeRunMode(value ? VacuumCleanerRunMode.Cleaning : VacuumCleanerRunMode.Idle),
         });
 
-        // Only one property may be mapped to an attribute path, and the one registered last wins it, so POWER is
-        // updated from here rather than from its own registration - which then only serves the initial read.
         this.enableDeviceTypeStateForAttribute(PropertyType.RunMode, {
             endpointId,
             clusterId: RvcRunMode.id,
             attributeName: 'currentMode',
             modes: this.#runModes(),
-            convertValue: async (value: number) => {
-                const power = this.#powerOf(value);
-                if (power !== undefined) {
-                    await this.ioBrokerDevice.updatePower(power);
-                }
-                return this.#runModeOf(value);
-            },
+            convertValue: (value: number) => this.#runModeOf(value),
             changeHandler: async (value: VacuumCleanerRunMode) => this.#changeRunMode(value),
         });
 
@@ -242,10 +249,7 @@ export class RoboticVacuumCleanerToIoBroker extends GenericDeviceToIoBroker {
         const usedCleanModeValues = new Set<string>();
         for (const option of this.#cleanModeOptions()) {
             // Two labels can normalize to the same value, and the reverse lookup a write does needs them distinct
-            let value = modeLabelToEnumValue(option.label, option.mode);
-            if (usedCleanModeValues.has(value)) {
-                value = `${value}_${option.mode}`;
-            }
+            const value = uniqueEnumValue(modeLabelToEnumValue(option.label, option.mode), usedCleanModeValues);
             usedCleanModeValues.add(value);
             cleanModes[option.mode] = value;
         }

--- a/src/matter/to-iobroker/ioBrokerFactory.ts
+++ b/src/matter/to-iobroker/ioBrokerFactory.ts
@@ -29,6 +29,7 @@ import { FanToIoBroker } from './FanToIoBroker';
 import { FlowSensorToIoBroker } from './FlowSensorToIoBroker';
 import { PressureSensorToIoBroker } from './PressureSensorToIoBroker';
 import { PumpToIoBroker } from './PumpToIoBroker';
+import { RoboticVacuumCleanerToIoBroker } from './RoboticVacuumCleanerToIoBroker';
 
 export function identifyDeviceTypes(endpoint: Endpoint): {
     utilityTypes: { deviceType: DeviceTypeModel; revision: number }[];
@@ -197,6 +198,9 @@ async function ioBrokerDeviceFabric(
             break;
         case Devices.PumpDeviceDefinition.deviceType:
             DeviceType = PumpToIoBroker;
+            break;
+        case Devices.RoboticVacuumCleanerDeviceDefinition.deviceType:
+            DeviceType = RoboticVacuumCleanerToIoBroker;
             break;
         case Devices.SmokeCoAlarmDeviceDefinition.deviceType:
             DeviceType = SmokeCoAlarmToIoBroker;

--- a/src/matter/to-matter/VacuumCleanerToMatter.ts
+++ b/src/matter/to-matter/VacuumCleanerToMatter.ts
@@ -37,6 +37,26 @@ const OPERATIONAL_STATE_BY_IOBROKER_STATE = new Map<VacuumCleanerState, RvcOpera
     [VacuumCleanerState.PAUSE, RvcOperationalState.OperationalState.Paused],
 ]);
 
+/**
+ * A discriminated form of a value that is not taken yet. The discriminator keeps counting because the form it
+ * produces can collide with a value the device already uses.
+ */
+function uniqueValue(
+    base: string,
+    taken: ReadonlySet<string>,
+    discriminate: (base: string, n: number) => string,
+): string {
+    if (!taken.has(base)) {
+        return base;
+    }
+    let discriminator = 2;
+    let candidate = discriminate(base, discriminator);
+    while (taken.has(candidate)) {
+        candidate = discriminate(base, ++discriminator);
+    }
+    return candidate;
+}
+
 /** Matter constrains a mode label to 64 characters, while an ioBroker state may name its modes freely. */
 const MAX_MODE_LABEL_LENGTH = 64;
 
@@ -95,6 +115,7 @@ export class VacuumCleanerToMatter extends GenericDeviceToMatter {
                 rvcOperationalState: {
                     operationalStateList: OPERATIONAL_STATE_LIST,
                     operationalState: this.#currentOperationalState(),
+                    operationalError: { errorStateId: this.#currentErrorState() },
                 },
                 ...(this.#cleanModes.length > 0
                     ? {
@@ -168,11 +189,10 @@ export class VacuumCleanerToMatter extends GenericDeviceToMatter {
         const usedLabels = new Set<string>();
         return this.#cleanModes.map((mode, index) => {
             // Matter rejects a duplicate label outright, and an ioBroker state may name two of its modes alike
-            let label = mode.substring(0, MAX_MODE_LABEL_LENGTH);
-            if (usedLabels.has(label)) {
-                const suffix = ` ${index}`;
-                label = `${label.substring(0, MAX_MODE_LABEL_LENGTH - suffix.length)}${suffix}`;
-            }
+            const label = uniqueValue(mode.substring(0, MAX_MODE_LABEL_LENGTH), usedLabels, (base, discriminator) => {
+                const suffix = ` ${discriminator}`;
+                return `${base.substring(0, MAX_MODE_LABEL_LENGTH - suffix.length)}${suffix}`;
+            });
             usedLabels.add(label);
 
             const semanticTag = CLEAN_MODE_TAGS[mode];
@@ -193,6 +213,13 @@ export class VacuumCleanerToMatter extends GenericDeviceToMatter {
         const mode = this.#ioBrokerDevice.getMode();
         const index = mode === undefined ? -1 : this.#cleanModes.indexOf(mode);
         return index === -1 ? 0 : index;
+    }
+
+    /** The operational state and the error attribute have to agree, or a controller sees an error with no cause. */
+    #currentErrorState(): OperationalState.ErrorState {
+        return this.#ioBrokerDevice.hasError() && this.#ioBrokerDevice.getError()
+            ? OperationalState.ErrorState.UnableToCompleteOperation
+            : OperationalState.ErrorState.NoError;
     }
 
     #currentOperationalState(): RvcOperationalState.OperationalState {

--- a/src/matter/to-matter/VacuumCleanerToMatter.ts
+++ b/src/matter/to-matter/VacuumCleanerToMatter.ts
@@ -1,0 +1,330 @@
+import { Endpoint } from '@matter/main';
+import { RoboticVacuumCleanerDevice } from '@matter/main/devices';
+import { ModeBase, OperationalState, RvcCleanMode, RvcOperationalState, RvcRunMode } from '@matter/main/clusters';
+import { PropertyType } from '../../lib/devices/DeviceStateObject';
+import {
+    type VacuumCleaner,
+    type VacuumCleanerMode,
+    VacuumCleanerRunMode,
+    VacuumCleanerRunModeNumbers,
+    VacuumCleanerState,
+} from '../../lib/devices/VacuumCleaner';
+import { GenericDeviceToMatter } from './GenericDeviceToMatter';
+import { IoIdentifyServer } from '../behaviors/IdentifyServer';
+import { IoBrokerContext } from '../behaviors/IoBrokerContext';
+import {
+    IoRvcCleanModeServer,
+    IoRvcOperationalStateServer,
+    IoRvcOperationalStateServerWithGoHome,
+    IoRvcOperationalStateServerWithPause,
+    IoRvcOperationalStateServerWithPauseAndGoHome,
+    IoRvcRunModeServer,
+} from '../behaviors/EventedRvcServers';
+
+const OPERATIONAL_STATE_LIST = [
+    { operationalStateId: RvcOperationalState.OperationalState.Stopped },
+    { operationalStateId: RvcOperationalState.OperationalState.Running },
+    { operationalStateId: RvcOperationalState.OperationalState.Paused },
+    { operationalStateId: RvcOperationalState.OperationalState.Error },
+    { operationalStateId: RvcOperationalState.OperationalState.SeekingCharger },
+    { operationalStateId: RvcOperationalState.OperationalState.Charging },
+    { operationalStateId: RvcOperationalState.OperationalState.Docked },
+];
+
+const OPERATIONAL_STATE_BY_IOBROKER_STATE = new Map<VacuumCleanerState, RvcOperationalState.OperationalState>([
+    [VacuumCleanerState.HOME, RvcOperationalState.OperationalState.Docked],
+    [VacuumCleanerState.CLEANING, RvcOperationalState.OperationalState.Running],
+    [VacuumCleanerState.PAUSE, RvcOperationalState.OperationalState.Paused],
+]);
+
+/** Matter constrains a mode label to 64 characters, while an ioBroker state may name its modes freely. */
+const MAX_MODE_LABEL_LENGTH = 64;
+
+/** RvcCleanMode needs at least two modes, and needs one of them tagged Vacuum or Mop. */
+const MIN_CLEAN_MODES = 2;
+
+const CLEAN_MODE_TAGS: Record<string, ModeBase.ModeTag> = {
+    AUTO: ModeBase.ModeTag.Auto,
+    QUIET: ModeBase.ModeTag.Quiet,
+    ECO: ModeBase.ModeTag.LowEnergy,
+    EXPRESS: ModeBase.ModeTag.Quick,
+};
+
+/** Mapping Logic to map an ioBroker Vacuum Cleaner device to a Matter RoboticVacuumCleanerDevice. */
+export class VacuumCleanerToMatter extends GenericDeviceToMatter {
+    readonly #ioBrokerDevice: VacuumCleaner;
+    readonly #matterEndpoint: Endpoint;
+    readonly #operationalStateServer;
+    readonly #cleanModes: VacuumCleanerMode[];
+    readonly #hasMapping: boolean;
+
+    constructor(ioBrokerDevice: VacuumCleaner, name: string, uuid: string) {
+        super(name, uuid);
+        this.#ioBrokerDevice = ioBrokerDevice;
+        const cleanModes = ioBrokerDevice.hasMode() ? ioBrokerDevice.getModes() : [];
+        this.#cleanModes = cleanModes.length >= MIN_CLEAN_MODES ? cleanModes : [];
+        this.#hasMapping =
+            ioBrokerDevice.hasRunMode() && ioBrokerDevice.getRunModeModes().includes(VacuumCleanerRunMode.Mapping);
+
+        const hasPause = ioBrokerDevice.hasPause();
+        const hasHome = ioBrokerDevice.hasHome();
+        this.#operationalStateServer = hasPause
+            ? hasHome
+                ? IoRvcOperationalStateServerWithPauseAndGoHome
+                : IoRvcOperationalStateServerWithPause
+            : hasHome
+              ? IoRvcOperationalStateServerWithGoHome
+              : IoRvcOperationalStateServer;
+
+        const deviceType = RoboticVacuumCleanerDevice.with(
+            IoIdentifyServer,
+            IoBrokerContext,
+            IoRvcRunModeServer,
+            this.#operationalStateServer,
+        );
+
+        this.#matterEndpoint = new Endpoint(
+            this.#cleanModes.length > 0 ? deviceType.with(IoRvcCleanModeServer) : deviceType,
+            {
+                id: `${uuid}-VacuumCleaner`,
+                ioBrokerContext: { device: ioBrokerDevice, adapter: ioBrokerDevice.adapter },
+                rvcRunMode: {
+                    supportedModes: this.#supportedRunModes(),
+                    currentMode: this.#currentRunMode(),
+                },
+                rvcOperationalState: {
+                    operationalStateList: OPERATIONAL_STATE_LIST,
+                    operationalState: this.#currentOperationalState(),
+                },
+                ...(this.#cleanModes.length > 0
+                    ? {
+                          rvcCleanMode: {
+                              supportedModes: this.#supportedCleanModes(),
+                              currentMode: this.#currentCleanMode(),
+                          },
+                      }
+                    : {}),
+            },
+        );
+    }
+
+    get matterEndpoints(): Endpoint[] {
+        return [this.#matterEndpoint];
+    }
+
+    get ioBrokerDevice(): VacuumCleaner {
+        return this.#ioBrokerDevice;
+    }
+
+    #supportedRunModes(): { label: string; mode: number; modeTags: { value: RvcRunMode.ModeTag }[] }[] {
+        const modes = [
+            {
+                label: 'Idle',
+                mode: VacuumCleanerRunModeNumbers.IDLE,
+                modeTags: [{ value: RvcRunMode.ModeTag.Idle }],
+            },
+            {
+                label: 'Cleaning',
+                mode: VacuumCleanerRunModeNumbers.CLEANING,
+                modeTags: [{ value: RvcRunMode.ModeTag.Cleaning }],
+            },
+        ];
+        if (this.#hasMapping) {
+            modes.push({
+                label: 'Mapping',
+                mode: VacuumCleanerRunModeNumbers.MAPPING,
+                modeTags: [{ value: RvcRunMode.ModeTag.Mapping }],
+            });
+        }
+        return modes;
+    }
+
+    #currentRunMode(): number {
+        if (this.#ioBrokerDevice.hasRunMode()) {
+            switch (this.#ioBrokerDevice.getRunMode()) {
+                case VacuumCleanerRunMode.Cleaning:
+                    return VacuumCleanerRunModeNumbers.CLEANING;
+                case VacuumCleanerRunMode.Mapping:
+                    if (this.#hasMapping) {
+                        return VacuumCleanerRunModeNumbers.MAPPING;
+                    }
+                    return VacuumCleanerRunModeNumbers.CLEANING;
+                case VacuumCleanerRunMode.Idle:
+                    return VacuumCleanerRunModeNumbers.IDLE;
+            }
+        }
+        return this.#isPowered() ? VacuumCleanerRunModeNumbers.CLEANING : VacuumCleanerRunModeNumbers.IDLE;
+    }
+
+    #isPowered(): boolean {
+        return this.#ioBrokerDevice.hasPower() ? !!this.#ioBrokerDevice.getPower() : false;
+    }
+
+    #supportedCleanModes(): {
+        label: string;
+        mode: number;
+        modeTags: { value: RvcCleanMode.ModeTag | ModeBase.ModeTag }[];
+    }[] {
+        const usedLabels = new Set<string>();
+        return this.#cleanModes.map((mode, index) => {
+            // Matter rejects a duplicate label outright, and an ioBroker state may name two of its modes alike
+            let label = mode.substring(0, MAX_MODE_LABEL_LENGTH);
+            if (usedLabels.has(label)) {
+                const suffix = ` ${index}`;
+                label = `${label.substring(0, MAX_MODE_LABEL_LENGTH - suffix.length)}${suffix}`;
+            }
+            usedLabels.add(label);
+
+            const semanticTag = CLEAN_MODE_TAGS[mode];
+            // One Vacuum or Mop mode is required, and an ioBroker cleaning mode names an intensity rather than a
+            // floor treatment, so vacuuming is the only thing every one of them can be said to be doing.
+            const modeTags: { value: RvcCleanMode.ModeTag | ModeBase.ModeTag }[] = [
+                { value: RvcCleanMode.ModeTag.Vacuum },
+            ];
+            if (semanticTag !== undefined) {
+                modeTags.push({ value: semanticTag });
+            }
+            return { label, mode: index, modeTags };
+        });
+    }
+
+    /** The cluster demands a current mode, so a value the device does not list falls back to its first one. */
+    #currentCleanMode(): number {
+        const mode = this.#ioBrokerDevice.getMode();
+        const index = mode === undefined ? -1 : this.#cleanModes.indexOf(mode);
+        return index === -1 ? 0 : index;
+    }
+
+    #currentOperationalState(): RvcOperationalState.OperationalState {
+        if (this.#ioBrokerDevice.hasError() && this.#ioBrokerDevice.getError()) {
+            return RvcOperationalState.OperationalState.Error;
+        }
+        if (this.#ioBrokerDevice.hasState()) {
+            const state = this.#ioBrokerDevice.getState();
+            const operationalState = state === undefined ? undefined : OPERATIONAL_STATE_BY_IOBROKER_STATE.get(state);
+            if (operationalState !== undefined) {
+                return operationalState;
+            }
+        }
+        return this.#isPowered()
+            ? RvcOperationalState.OperationalState.Running
+            : RvcOperationalState.OperationalState.Docked;
+    }
+
+    async #setOperationalState(operationalState: RvcOperationalState.OperationalState): Promise<void> {
+        await this.#matterEndpoint.setStateOf(this.#operationalStateServer, { operationalState });
+    }
+
+    async registerHandlersAndInitialize(): Promise<void> {
+        await super.registerHandlersAndInitialize();
+
+        this.#registerMatterHandlers();
+        this.#registerIoBrokerHandlers();
+    }
+
+    #registerMatterHandlers(): void {
+        this.matterEvents.on(this.#matterEndpoint.eventsOf(IoRvcRunModeServer).rvcRunModeControlled, async mode => {
+            await this.#handleMatterRunModeChange(mode);
+        });
+
+        if (this.#cleanModes.length > 0) {
+            this.matterEvents.on(
+                this.#matterEndpoint.eventsOf(IoRvcCleanModeServer).rvcCleanModeControlled,
+                async mode => {
+                    const cleanMode = this.#cleanModes[mode];
+                    if (cleanMode !== undefined) {
+                        await this.#ioBrokerDevice.setMode(cleanMode);
+                    }
+                },
+            );
+        }
+
+        const operationalStateEvents = this.#matterEndpoint.eventsOf(this.#operationalStateServer);
+        if (this.#ioBrokerDevice.hasPause()) {
+            this.matterEvents.on(operationalStateEvents.rvcPauseTriggered, async () => {
+                await this.#ioBrokerDevice.setPause(true);
+                await this.#reportCommandResult(RvcOperationalState.OperationalState.Paused);
+            });
+            this.matterEvents.on(operationalStateEvents.rvcResumeTriggered, async () => {
+                await this.#ioBrokerDevice.setPause(false);
+                await this.#reportCommandResult(RvcOperationalState.OperationalState.Running);
+            });
+        }
+        if (this.#ioBrokerDevice.hasHome()) {
+            this.matterEvents.on(operationalStateEvents.rvcGoHomeTriggered, async () => {
+                await this.#ioBrokerDevice.setHome(true);
+                await this.#reportCommandResult(RvcOperationalState.OperationalState.Docked);
+            });
+        }
+    }
+
+    /**
+     * Without a STATE state nothing reports back what the command did, and a controller that never sees the robot leave
+     * its old state cannot issue the opposite command afterwards.
+     */
+    async #reportCommandResult(operationalState: RvcOperationalState.OperationalState): Promise<void> {
+        if (!this.#ioBrokerDevice.hasState()) {
+            await this.#setOperationalState(operationalState);
+        }
+    }
+
+    async #handleMatterRunModeChange(mode: number): Promise<void> {
+        const runMode =
+            mode === VacuumCleanerRunModeNumbers.MAPPING
+                ? VacuumCleanerRunMode.Mapping
+                : mode === VacuumCleanerRunModeNumbers.CLEANING
+                  ? VacuumCleanerRunMode.Cleaning
+                  : VacuumCleanerRunMode.Idle;
+
+        if (this.#ioBrokerDevice.hasRunMode()) {
+            await this.#ioBrokerDevice.setRunMode(runMode);
+        }
+        const powered = runMode !== VacuumCleanerRunMode.Idle;
+        if (this.#ioBrokerDevice.hasPower() && this.#isPowered() !== powered) {
+            await this.#ioBrokerDevice.setPower(powered);
+        }
+        if (!this.#ioBrokerDevice.hasState()) {
+            await this.#setOperationalState(
+                powered ? RvcOperationalState.OperationalState.Running : RvcOperationalState.OperationalState.Docked,
+            );
+        }
+    }
+
+    #registerIoBrokerHandlers(): void {
+        this.#ioBrokerDevice.onChange(async event => {
+            switch (event.property) {
+                case PropertyType.RunMode:
+                case PropertyType.Power:
+                    await this.#matterEndpoint.setStateOf(IoRvcRunModeServer, { currentMode: this.#currentRunMode() });
+                    await this.#setOperationalState(this.#currentOperationalState());
+                    break;
+                case PropertyType.Mode:
+                    if (this.#cleanModes.length > 0) {
+                        const index = this.#cleanModes.findIndex(mode => mode === event.value);
+                        if (index !== -1) {
+                            await this.#matterEndpoint.setStateOf(IoRvcCleanModeServer, { currentMode: index });
+                        }
+                    }
+                    break;
+                case PropertyType.State:
+                    await this.#setOperationalState(this.#currentOperationalState());
+                    break;
+                case PropertyType.Error:
+                    if (event.value) {
+                        await this.#matterEndpoint.setStateOf(this.#operationalStateServer, {
+                            operationalError: {
+                                errorStateId: OperationalState.ErrorState.UnableToCompleteOperation,
+                            },
+                        });
+                    } else {
+                        // Clearing the error attribute alone leaves the cluster in Error, so the state has to follow
+                        await this.#matterEndpoint.setStateOf(this.#operationalStateServer, {
+                            operationalError: { errorStateId: OperationalState.ErrorState.NoError },
+                        });
+                        await this.#setOperationalState(this.#currentOperationalState());
+                    }
+                    break;
+            }
+        });
+    }
+}

--- a/src/matter/to-matter/VacuumCleanerToMatter.ts
+++ b/src/matter/to-matter/VacuumCleanerToMatter.ts
@@ -63,6 +63,9 @@ const MAX_MODE_LABEL_LENGTH = 64;
 /** RvcCleanMode needs at least two modes, and needs one of them tagged Vacuum or Mop. */
 const MIN_CLEAN_MODES = 2;
 
+/** The upper bound the cluster puts on supportedModes. */
+const MAX_CLEAN_MODES = 255;
+
 const CLEAN_MODE_TAGS: Record<string, ModeBase.ModeTag> = {
     AUTO: ModeBase.ModeTag.Auto,
     QUIET: ModeBase.ModeTag.Quiet,
@@ -81,7 +84,12 @@ export class VacuumCleanerToMatter extends GenericDeviceToMatter {
     constructor(ioBrokerDevice: VacuumCleaner, name: string, uuid: string) {
         super(name, uuid);
         this.#ioBrokerDevice = ioBrokerDevice;
-        const cleanModes = ioBrokerDevice.hasMode() ? ioBrokerDevice.getModes() : [];
+        // A write carries the ioBroker mode name, and a name reverse-maps to the first state holding it, so a mode
+        // repeating a name could never be selected. Offering it anyway would advertise a mode that does nothing.
+        const cleanModes = [...new Set(ioBrokerDevice.hasMode() ? ioBrokerDevice.getModes() : [])].slice(
+            0,
+            MAX_CLEAN_MODES,
+        );
         this.#cleanModes = cleanModes.length >= MIN_CLEAN_MODES ? cleanModes : [];
         this.#hasMapping =
             ioBrokerDevice.hasRunMode() && ioBrokerDevice.getRunModeModes().includes(VacuumCleanerRunMode.Mapping);
@@ -175,6 +183,23 @@ export class VacuumCleanerToMatter extends GenericDeviceToMatter {
             }
         }
         return this.#isPowered() ? VacuumCleanerRunModeNumbers.CLEANING : VacuumCleanerRunModeNumbers.IDLE;
+    }
+
+    async #setRunMode(currentMode: number): Promise<void> {
+        await this.#matterEndpoint.setStateOf(IoRvcRunModeServer, { currentMode });
+        await this.#setOperationalState(this.#currentOperationalState());
+    }
+
+    /**
+     * POWER and RUN_MODE can disagree, and the run mode of a device says nothing about whether it is switched on, so
+     * a power change decides on its own. A robot switched on still has to be doing something.
+     */
+    #runModeForPower(powered: boolean): number {
+        if (!powered) {
+            return VacuumCleanerRunModeNumbers.IDLE;
+        }
+        const runMode = this.#currentRunMode();
+        return runMode === VacuumCleanerRunModeNumbers.IDLE ? VacuumCleanerRunModeNumbers.CLEANING : runMode;
     }
 
     #isPowered(): boolean {
@@ -321,9 +346,10 @@ export class VacuumCleanerToMatter extends GenericDeviceToMatter {
         this.#ioBrokerDevice.onChange(async event => {
             switch (event.property) {
                 case PropertyType.RunMode:
+                    await this.#setRunMode(this.#currentRunMode());
+                    break;
                 case PropertyType.Power:
-                    await this.#matterEndpoint.setStateOf(IoRvcRunModeServer, { currentMode: this.#currentRunMode() });
-                    await this.#setOperationalState(this.#currentOperationalState());
+                    await this.#setRunMode(this.#runModeForPower(!!event.value));
                     break;
                 case PropertyType.Mode:
                     if (this.#cleanModes.length > 0) {

--- a/src/matter/to-matter/matterFactory.ts
+++ b/src/matter/to-matter/matterFactory.ts
@@ -29,6 +29,7 @@ import { ThermostatToMatter } from './ThermostatToMatter';
 import { HueAndRgbToMatter } from './HueAndRgbToMatter';
 import { CieToMatter } from './CieToMatter';
 import { VolumeToMatter } from './VolumeToMatter';
+import { VacuumCleanerToMatter } from './VacuumCleanerToMatter';
 
 /**
  * Factory function to create a Matter device from an ioBroker device.
@@ -123,6 +124,9 @@ async function matterDeviceFabric(
             break;
         case Types.thermostat:
             ToMatter = ThermostatToMatter;
+            break;
+        case Types.vacuumCleaner:
+            ToMatter = VacuumCleanerToMatter;
             break;
         case Types.volume:
         case Types.volumeGroup:

--- a/test/fixtures/TestBridgeDevice.ts
+++ b/test/fixtures/TestBridgeDevice.ts
@@ -406,6 +406,26 @@ async function main(): Promise<void> {
             ActivatedCarbonFilterMonitoringServer.with('Condition', 'Warning'),
         ],
     );
+    // Only the carbon filter monitors, so the state the two monitoring clusters share has to be owned by that one
+    await addBridged(
+        'airpurifiercarbon',
+        Devices.AirPurifierDevice,
+        {
+            onOff: { onOff: true },
+            fanControl: {
+                fanMode: FanControl.FanMode.High,
+                fanModeSequence: FanControl.FanModeSequence.OffLowMedHigh,
+                percentCurrent: 90,
+                percentSetting: 90,
+            },
+            activatedCarbonFilterMonitoring: {
+                condition: 40,
+                degradationDirection: ResourceMonitoring.DegradationDirection.Down,
+                changeIndication: ResourceMonitoring.ChangeIndication.Warning,
+            },
+        },
+        [OnOffServer, ActivatedCarbonFilterMonitoringServer.with('Condition', 'Warning')],
+    );
     await addBridged(
         'pump',
         Devices.PumpDevice,

--- a/test/fixtures/TestBridgeDevice.ts
+++ b/test/fixtures/TestBridgeDevice.ts
@@ -6,7 +6,7 @@
  *   npx ts-node --project tsconfig.test.json test/fixtures/TestBridgeDevice.ts --storage-path=<path> --port=<port>
  */
 
-import { Endpoint, Environment, MutableEndpoint, ServerNode, VendorId } from '@matter/main';
+import { CommonAreaNamespaceTag, Endpoint, Environment, MutableEndpoint, ServerNode, VendorId } from '@matter/main';
 import type { Behavior, SupportedBehaviors } from '@matter/main';
 import {
     ActivatedCarbonFilterMonitoringServer,
@@ -26,6 +26,10 @@ import {
     PressureMeasurementServer,
     PumpConfigurationAndControlServer,
     RelativeHumidityMeasurementServer,
+    RvcCleanModeServer,
+    RvcOperationalStateServer,
+    RvcRunModeServer,
+    ServiceAreaServer,
     SmokeCoAlarmServer,
     SwitchServer,
     TemperatureControlServer,
@@ -35,6 +39,7 @@ import {
     WindowCoveringServer,
 } from '@matter/main/behaviors';
 import { AggregatorEndpoint, PowerSourceEndpoint } from '@matter/main/endpoints';
+import { OperationalStateUtils } from '@matter/main/behaviors';
 import {
     AirQuality,
     ColorControl,
@@ -45,12 +50,34 @@ import {
     PowerSource,
     PumpConfigurationAndControl,
     ResourceMonitoring,
+    RvcCleanMode,
+    RvcOperationalState,
+    RvcRunMode,
+    ServiceArea,
     SmokeCoAlarm,
     Thermostat,
     WindowCovering,
 } from '@matter/main/clusters';
 import * as Devices from '@matter/main/devices';
 import { BRIDGE_DISCRIMINATOR, BRIDGE_PASSCODE, BRIDGE_PORT_BASE, READY_MARKER } from './bridgeConstants';
+
+/**
+ * A robot that accepts the optional operational-state commands. Matter derives the accepted command list from the
+ * methods a behavior implements, so the default server would advertise none of them.
+ */
+class CommandingRvcOperationalStateServer extends RvcOperationalStateServer {
+    override pause(): RvcOperationalState.OperationalCommandResponse {
+        return OperationalStateUtils.assertRvcPause(this.state.operationalState);
+    }
+
+    override resume(): RvcOperationalState.OperationalCommandResponse {
+        return OperationalStateUtils.assertRvcResume(this.state.operationalState);
+    }
+
+    override goHome(): RvcOperationalState.OperationalCommandResponse {
+        return OperationalStateUtils.assertRvcGoHome(this.state.operationalState);
+    }
+}
 
 const args = process.argv.slice(2);
 const argValue = (name: string): string | undefined => args.find(a => a.startsWith(`--${name}=`))?.split('=')[1];
@@ -402,6 +429,112 @@ async function main(): Promise<void> {
             PressureMeasurementServer,
             FlowMeasurementServer,
         ],
+    );
+
+    // A robot with all five RVC clusters. Its mode numbers are deliberately not the ioBroker ones: they are vendor
+    // defined, so only the mode tags may decide what a mode means.
+    await addBridged(
+        'roboticvacuum',
+        Devices.RoboticVacuumCleanerDevice,
+        {
+            rvcRunMode: {
+                supportedModes: [
+                    { label: 'Idle', mode: 7, modeTags: [{ value: RvcRunMode.ModeTag.Idle }] },
+                    { label: 'Cleaning', mode: 3, modeTags: [{ value: RvcRunMode.ModeTag.Cleaning }] },
+                    { label: 'Mapping', mode: 9, modeTags: [{ value: RvcRunMode.ModeTag.Mapping }] },
+                ],
+                currentMode: 3,
+            },
+            rvcCleanMode: {
+                supportedModes: [
+                    { label: 'Vacuuming', mode: 5, modeTags: [{ value: RvcCleanMode.ModeTag.Vacuum }] },
+                    { label: 'Deep Clean', mode: 2, modeTags: [{ value: RvcCleanMode.ModeTag.DeepClean }] },
+                ],
+                currentMode: 2,
+            },
+            rvcOperationalState: {
+                operationalStateList: [
+                    { operationalStateId: RvcOperationalState.OperationalState.Running },
+                    { operationalStateId: RvcOperationalState.OperationalState.Paused },
+                    { operationalStateId: RvcOperationalState.OperationalState.Error },
+                    { operationalStateId: RvcOperationalState.OperationalState.SeekingCharger },
+                    { operationalStateId: RvcOperationalState.OperationalState.Charging },
+                    { operationalStateId: RvcOperationalState.OperationalState.Docked },
+                ],
+                operationalState: RvcOperationalState.OperationalState.Running,
+                phaseList: ['Sweeping', 'Mopping'],
+                currentPhase: 0,
+            },
+            serviceArea: {
+                supportedMaps: [{ mapId: 0, name: 'Ground Floor' }],
+                supportedAreas: [
+                    {
+                        areaId: 0,
+                        mapId: 0,
+                        areaInfo: {
+                            locationInfo: {
+                                locationName: 'Kitchen',
+                                floorNumber: 0,
+                                areaType: CommonAreaNamespaceTag.Kitchen.tag,
+                            },
+                            landmarkInfo: null,
+                        },
+                    },
+                    {
+                        areaId: 1,
+                        mapId: 0,
+                        areaInfo: {
+                            locationInfo: {
+                                locationName: 'Living Room',
+                                floorNumber: 0,
+                                areaType: CommonAreaNamespaceTag.LivingRoom.tag,
+                            },
+                            landmarkInfo: null,
+                        },
+                    },
+                ],
+                selectedAreas: [0, 1],
+                currentArea: 1,
+                // One of the two selected areas is done, so the ioBroker progress percentage must be 50.
+                progress: [
+                    { areaId: 0, status: ServiceArea.OperationalStatus.Completed },
+                    { areaId: 1, status: ServiceArea.OperationalStatus.Operating },
+                ],
+            },
+        },
+        [
+            RvcRunModeServer,
+            CommandingRvcOperationalStateServer,
+            RvcCleanModeServer,
+            ServiceAreaServer.with('SelectWhileRunning', 'ProgressReporting', 'Maps'),
+        ],
+    );
+
+    // A robot that accepts no optional command and reports no clean mode, so the states behind those must not exist.
+    // Its ServiceArea reports no progress at all, which is not the same as no progress having been made.
+    await addBridged(
+        'roboticvacuumbasic',
+        Devices.RoboticVacuumCleanerDevice,
+        {
+            rvcRunMode: {
+                supportedModes: [
+                    { label: 'Idle', mode: 0, modeTags: [{ value: RvcRunMode.ModeTag.Idle }] },
+                    { label: 'Cleaning', mode: 1, modeTags: [{ value: RvcRunMode.ModeTag.Cleaning }] },
+                ],
+                currentMode: 0,
+            },
+            rvcOperationalState: {
+                operationalStateList: [
+                    { operationalStateId: RvcOperationalState.OperationalState.Running },
+                    { operationalStateId: RvcOperationalState.OperationalState.Error },
+                    { operationalStateId: RvcOperationalState.OperationalState.Docked },
+                ],
+                operationalState: RvcOperationalState.OperationalState.Docked,
+            },
+            // matter.js 0.17.9 asserts supportedMaps unconditionally, so the Maps feature cannot be left out here
+            serviceArea: { supportedMaps: [], supportedAreas: [], selectedAreas: [], progress: [] },
+        },
+        [RvcRunModeServer, RvcOperationalStateServer, ServiceAreaServer.with('ProgressReporting', 'Maps')],
     );
 
     /**

--- a/test/fixtures/testBridgeDefinition.ts
+++ b/test/fixtures/testBridgeDefinition.ts
@@ -346,6 +346,22 @@ export const SENSOR_AND_APPLIANCE_ENDPOINTS: BridgedEndpointSpec[] = [
         },
     },
     {
+        id: 'airpurifiercarbon',
+        deviceType: 0x002d,
+        expectedConverter: 'AirPurifierToIoBroker',
+        expectedIoBrokerType: 'airPurifier',
+        // No HEPA cluster, so FILTER_CONDITION cannot exist while the shared FILTER_CHANGE still has to
+        expectedStates: [
+            'FILTER_CHANGE',
+            'FILTER_CONDITION_CARBON',
+            'POWER',
+            'SPEED',
+            'SPEED_LEVEL',
+            ...CONNECTION_STATES,
+        ],
+        expectedValues: { SPEED: 1, SPEED_LEVEL: 90, POWER: true, FILTER_CONDITION_CARBON: 40, FILTER_CHANGE: true },
+    },
+    {
         id: 'pump',
         deviceType: 0x0303,
         expectedConverter: 'PumpToIoBroker',

--- a/test/fixtures/testBridgeDefinition.ts
+++ b/test/fixtures/testBridgeDefinition.ts
@@ -354,6 +354,45 @@ export const SENSOR_AND_APPLIANCE_ENDPOINTS: BridgedEndpointSpec[] = [
         // currentLevel 127 of 254 is 50%, MeasuredValue 4550 is 45.5 °C, 2000 is 2000 mbar, 250 is 25 m³/h.
         expectedValues: { POWER: false, LEVEL: 50, TEMPERATURE: 45.5, PRESSURE: 2000, FLOW: 25 },
     },
+    {
+        id: 'roboticvacuum',
+        deviceType: 0x0074,
+        expectedConverter: 'RoboticVacuumCleanerToIoBroker',
+        expectedIoBrokerType: 'vacuumCleaner',
+        expectedStates: [
+            'ERROR',
+            'HOME',
+            'MODE',
+            'PAUSE',
+            'PHASE',
+            'POWER',
+            'PROGRESS',
+            'RUN_MODE',
+            'STATE',
+            ...CONNECTION_STATES,
+        ],
+        // The robot runs its Cleaning mode as number 3, which must land on the ioBroker CLEANING key 1; STATE 1 is
+        // CLEANING too. MODE keeps the robot's own mode numbers, so its Deep Clean mode stays 2.
+        expectedValues: {
+            RUN_MODE: 1,
+            POWER: true,
+            MODE: 2,
+            STATE: 1,
+            PHASE: 'Sweeping',
+            PROGRESS: 50,
+            ERROR: '',
+        },
+    },
+    {
+        id: 'roboticvacuumbasic',
+        deviceType: 0x0074,
+        expectedConverter: 'RoboticVacuumCleanerToIoBroker',
+        expectedIoBrokerType: 'vacuumCleaner',
+        // No RvcCleanMode and no optional command, so MODE, PAUSE and HOME cannot exist. PROGRESS does, but an
+        // empty Matter progress list means the robot reports no progress, so no percentage may be invented for it.
+        expectedStates: ['ERROR', 'PHASE', 'POWER', 'PROGRESS', 'RUN_MODE', 'STATE', ...CONNECTION_STATES],
+        expectedValues: { RUN_MODE: 0, POWER: false, STATE: 0, ERROR: '', PROGRESS: undefined },
+    },
 ];
 
 /**

--- a/test/integration/controllerMapping.integration.ts
+++ b/test/integration/controllerMapping.integration.ts
@@ -14,6 +14,7 @@ import type { Endpoint } from '@matter/main';
 import { Logger, LogLevel } from '@matter/main';
 import { AttributeId, ClusterId, EndpointNumber } from '@matter/main/types';
 import { BridgedDeviceBasicInformationClient } from '@matter/main/behaviors';
+import { RvcOperationalState, RvcRunMode } from '@matter/main/clusters';
 import { AggregatorEndpointDefinition } from '@matter/main/endpoints';
 import { SubscribeManager } from '../../src/lib/SubscribeManager';
 import { toHex } from '../../src/lib/utils';
@@ -243,6 +244,67 @@ describe('Matter -> ioBroker controller mapping', function () {
             }
         });
     }
+
+    /**
+     * The per-endpoint checks above only see the values the mapping wrote at startup, so a property that is never
+     * updated again reads as correct there. These drive an attribute change through the production dispatch.
+     */
+    describe('attribute changes after the initial read', () => {
+        const pushAttribute = async (id: string, clusterId: number, attributeName: string, value: unknown) => {
+            const entry = mapped.get(id)!;
+            const cluster = clusterId === RvcRunMode.id ? RvcRunMode.Cluster : RvcOperationalState.Cluster;
+            const attribute = Reflect.get(cluster.attributes, attributeName) as { id: number };
+            await entry.device!.handleChangedAttribute({
+                endpointId: EndpointNumber(entry.device!.number),
+                clusterId: ClusterId(clusterId),
+                attributeId: AttributeId(attribute.id),
+                attributeName,
+                value,
+            });
+        };
+
+        it('carries a run mode change into both RUN_MODE and POWER', async () => {
+            const { baseId } = mapped.get('roboticvacuum')!;
+            expect(adapter.valueOf(baseId, 'RUN_MODE')).to.equal(1);
+            expect(adapter.valueOf(baseId, 'POWER')).to.equal(true);
+
+            // 7 is the robot's own Idle mode
+            await pushAttribute('roboticvacuum', RvcRunMode.id, 'currentMode', 7);
+            expect(adapter.valueOf(baseId, 'RUN_MODE')).to.equal(0);
+            expect(adapter.valueOf(baseId, 'POWER')).to.equal(false);
+
+            // 9 is its Mapping mode
+            await pushAttribute('roboticvacuum', RvcRunMode.id, 'currentMode', 9);
+            expect(adapter.valueOf(baseId, 'RUN_MODE')).to.equal(2);
+            expect(adapter.valueOf(baseId, 'POWER')).to.equal(true);
+        });
+
+        it('clears PHASE when the robot reports no phase', async () => {
+            const { baseId } = mapped.get('roboticvacuum')!;
+            expect(adapter.valueOf(baseId, 'PHASE')).to.equal('Sweeping');
+
+            await pushAttribute('roboticvacuum', RvcOperationalState.id, 'currentPhase', 1);
+            expect(adapter.valueOf(baseId, 'PHASE')).to.equal('Mopping');
+
+            await pushAttribute('roboticvacuum', RvcOperationalState.id, 'currentPhase', null);
+            expect(adapter.valueOf(baseId, 'PHASE')).to.equal('');
+        });
+
+        it('reports the robot error by name and clears it again', async () => {
+            const { baseId } = mapped.get('roboticvacuum')!;
+            expect(adapter.valueOf(baseId, 'ERROR')).to.equal('');
+
+            await pushAttribute('roboticvacuum', RvcOperationalState.id, 'operationalError', {
+                errorStateId: RvcOperationalState.ErrorState.DustBinFull,
+            });
+            expect(adapter.valueOf(baseId, 'ERROR')).to.equal('DustBinFull');
+
+            await pushAttribute('roboticvacuum', RvcOperationalState.id, 'operationalError', {
+                errorStateId: RvcOperationalState.ErrorState.NoError,
+            });
+            expect(adapter.valueOf(baseId, 'ERROR')).to.equal('');
+        });
+    });
 
     /**
      * The raw application cluster data of an endpoint must exist exactly once, split the same way the device

--- a/test/integration/controllerMapping.integration.ts
+++ b/test/integration/controllerMapping.integration.ts
@@ -14,7 +14,12 @@ import type { Endpoint } from '@matter/main';
 import { Logger, LogLevel } from '@matter/main';
 import { AttributeId, ClusterId, EndpointNumber } from '@matter/main/types';
 import { BridgedDeviceBasicInformationClient } from '@matter/main/behaviors';
-import { RvcOperationalState, RvcRunMode } from '@matter/main/clusters';
+import {
+    ActivatedCarbonFilterMonitoring,
+    ResourceMonitoring,
+    RvcOperationalState,
+    RvcRunMode,
+} from '@matter/main/clusters';
 import { AggregatorEndpointDefinition } from '@matter/main/endpoints';
 import { SubscribeManager } from '../../src/lib/SubscribeManager';
 import { toHex } from '../../src/lib/utils';
@@ -250,9 +255,11 @@ describe('Matter -> ioBroker controller mapping', function () {
      * updated again reads as correct there. These drive an attribute change through the production dispatch.
      */
     describe('attribute changes after the initial read', () => {
+        const CLUSTERS = [RvcRunMode.Cluster, RvcOperationalState.Cluster, ActivatedCarbonFilterMonitoring.Cluster];
+
         const pushAttribute = async (id: string, clusterId: number, attributeName: string, value: unknown) => {
             const entry = mapped.get(id)!;
-            const cluster = clusterId === RvcRunMode.id ? RvcRunMode.Cluster : RvcOperationalState.Cluster;
+            const cluster = CLUSTERS.find(candidate => candidate.id === clusterId)!;
             const attribute = Reflect.get(cluster.attributes, attributeName) as { id: number };
             await entry.device!.handleChangedAttribute({
                 endpointId: EndpointNumber(entry.device!.number),
@@ -288,6 +295,31 @@ describe('Matter -> ioBroker controller mapping', function () {
 
             await pushAttribute('roboticvacuum', RvcOperationalState.id, 'currentPhase', null);
             expect(adapter.valueOf(baseId, 'PHASE')).to.equal('');
+        });
+
+        /**
+         * The two filter monitoring clusters both feed one ioBroker state. A property is enabled once, so the second
+         * of them reaches the state through a handler of its own, and only a change proves that handler is wired.
+         */
+        it('carries a carbon filter change into the shared filter state', async () => {
+            const { baseId } = mapped.get('airpurifier')!;
+            expect(adapter.valueOf(baseId, 'FILTER_CHANGE')).to.equal(true);
+
+            await pushAttribute(
+                'airpurifier',
+                ActivatedCarbonFilterMonitoring.id,
+                'changeIndication',
+                ResourceMonitoring.ChangeIndication.Ok,
+            );
+            expect(adapter.valueOf(baseId, 'FILTER_CHANGE')).to.equal(false);
+
+            await pushAttribute(
+                'airpurifier',
+                ActivatedCarbonFilterMonitoring.id,
+                'changeIndication',
+                ResourceMonitoring.ChangeIndication.Warning,
+            );
+            expect(adapter.valueOf(baseId, 'FILTER_CHANGE')).to.equal(true);
         });
 
         it('reports the robot error by name and clears it again', async () => {

--- a/test/toMatterEndpoints.test.ts
+++ b/test/toMatterEndpoints.test.ts
@@ -687,8 +687,32 @@ describe('to-matter converters for type-detector v6 device types', function () {
             });
             const [endpoint] = endpointsOf(mounted);
             const labels = endpoint.state.rvcCleanMode.supportedModes.map((mode: any) => mode.label);
-            expect(labels).to.deep.equal(['AUTO', 'AUTO 1', 'TURBO']);
+            expect(labels).to.deep.equal(['AUTO', 'AUTO 2', 'TURBO']);
             expect(new Set(labels).size).to.equal(labels.length);
+        });
+
+        it('keeps suffixing until a mode name is actually unique', async () => {
+            const mounted = await mount(Types.vacuumCleaner, {
+                POWER: bool(false),
+                MODE: enumeration(['AUTO', 'AUTO 2', 'AUTO'], 0),
+            });
+            const [endpoint] = endpointsOf(mounted);
+            const labels = endpoint.state.rvcCleanMode.supportedModes.map((mode: any) => mode.label);
+            expect(labels).to.deep.equal(['AUTO', 'AUTO 2', 'AUTO 3']);
+        });
+
+        it('starts in Error with the error attribute that explains it', async () => {
+            const mounted = await mount(Types.vacuumCleaner, {
+                POWER: bool(true),
+                ERROR: { type: 'string', val: 'Stuck' },
+            });
+            const [endpoint] = endpointsOf(mounted);
+            expect(endpoint.state.rvcOperationalState.operationalState).to.equal(
+                RvcOperationalState.OperationalState.Error,
+            );
+            expect(endpoint.state.rvcOperationalState.operationalError.errorStateId).to.equal(
+                RvcOperationalState.ErrorState.UnableToCompleteOperation,
+            );
         });
 
         it('crops a mode name to the 64 characters a Matter label holds', async () => {

--- a/test/toMatterEndpoints.test.ts
+++ b/test/toMatterEndpoints.test.ts
@@ -12,9 +12,18 @@ import {
     VendorId,
 } from '@matter/main';
 import { MdnsService } from '@matter/main/protocol';
-import { ConcentrationMeasurement, FanControl, ResourceMonitoring } from '@matter/main/clusters';
+import {
+    ConcentrationMeasurement,
+    FanControl,
+    ModeBase,
+    ResourceMonitoring,
+    RvcCleanMode,
+    RvcOperationalState,
+    RvcRunMode,
+} from '@matter/main/clusters';
 import { StateType, Types } from '@iobroker/type-detector';
 import DeviceFactory from '../src/lib/DeviceFactory';
+import { PropertyType } from '../src/lib/devices/DeviceStateObject';
 import type { DetectedDevice, DeviceOptions, GenericDevice } from '../src/lib/devices/GenericDevice';
 import { SubscribeManager } from '../src/lib/SubscribeManager';
 import matterDeviceFabric from '../src/matter/to-matter/matterFactory';
@@ -26,6 +35,7 @@ import { FanToMatter } from '../src/matter/to-matter/FanToMatter';
 import { FlowToMatter } from '../src/matter/to-matter/FlowToMatter';
 import { PressureToMatter } from '../src/matter/to-matter/PressureToMatter';
 import { PumpToMatter } from '../src/matter/to-matter/PumpToMatter';
+import { VacuumCleanerToMatter } from '../src/matter/to-matter/VacuumCleanerToMatter';
 
 // ---------------------------------------------------------------------------------------------------------------
 // ioBroker side: a mock adapter that serves exactly the states a test asks for, so the hasX() gating in the
@@ -61,6 +71,10 @@ const enumeration = (labels: string[], val = 0): StateSpec => ({
 const FAN_SPEEDS = ['AUTO', 'HIGH', 'LOW', 'MEDIUM', 'QUIET', 'TURBO'];
 const FAN_SWINGS = ['AUTO', 'HORIZONTAL', 'STATIONARY', 'VERTICAL'];
 const AIRFLOW_DIRECTIONS = ['FORWARD', 'REVERSE'];
+const VACUUM_RUN_MODES = ['IDLE', 'CLEANING', 'MAPPING'];
+const VACUUM_MODES = ['AUTO', 'NORMAL', 'QUIET', 'ECO', 'EXPRESS'];
+const VACUUM_STATES = ['HOME', 'CLEANING', 'PAUSE'];
+
 const AQI_LEVELS = ['UNKNOWN', 'GOOD', 'FAIR', 'MODERATE', 'POOR', 'VERY_POOR', 'EXTREMELY_POOR'];
 const POLLUTANT_LEVELS = ['UNKNOWN', 'LOW', 'MEDIUM', 'HIGH', 'CRITICAL'];
 
@@ -582,6 +596,315 @@ describe('to-matter converters for type-detector v6 device types', function () {
             expect(endpoint.state.pumpConfigurationAndControl.pumpStatus.running).to.equal(true);
             await mounted.adapter.pushValue('LEVEL', 0);
             expect(endpoint.state.pumpConfigurationAndControl.pumpStatus.running).to.equal(false);
+        });
+    });
+
+    describe('VacuumCleanerToMatter', () => {
+        /** Invokes a cluster command the way a controller would, so the command handlers are covered end to end. */
+        async function invoke(endpoint: any, cluster: string, command: string, request?: any): Promise<any> {
+            return endpoint.act((agent: any) => agent[cluster][command](request));
+        }
+
+        it('offers the Idle and Cleaning run modes a robot without RUN_MODE can still be driven with', async () => {
+            const mounted = await mount(Types.vacuumCleaner, { POWER: bool(false) });
+            expect(mounted.converter).to.be.instanceOf(VacuumCleanerToMatter);
+            const [endpoint] = endpointsOf(mounted);
+            expect(endpoint.state.rvcRunMode.supportedModes.map((mode: any) => mode.mode)).to.deep.equal([0, 1]);
+            expect(endpoint.state.rvcRunMode.currentMode).to.equal(0);
+            expect(endpoint.behaviors.has('rvcCleanMode'), 'no MODE state must mean no RvcCleanMode').to.equal(false);
+            expect(endpoint.state.rvcOperationalState.operationalState).to.equal(
+                RvcOperationalState.OperationalState.Docked,
+            );
+        });
+
+        it('advertises pause, resume and go home only when the device has the states behind them', async () => {
+            const without = await mount(Types.vacuumCleaner, { POWER: bool(false) });
+            expect(endpointsOf(without)[0].state.rvcOperationalState.acceptedCommandList).to.deep.equal([]);
+
+            const withPauseOnly = await mount(Types.vacuumCleaner, { POWER: bool(false), PAUSE: bool(false) });
+            expect(endpointsOf(withPauseOnly)[0].state.rvcOperationalState.acceptedCommandList).to.deep.equal([0, 3]);
+
+            const withHomeOnly = await mount(Types.vacuumCleaner, { POWER: bool(false), HOME: bool(false) });
+            expect(endpointsOf(withHomeOnly)[0].state.rvcOperationalState.acceptedCommandList).to.deep.equal([128]);
+
+            const withBoth = await mount(Types.vacuumCleaner, {
+                POWER: bool(false),
+                PAUSE: bool(false),
+                HOME: bool(false),
+            });
+            expect(endpointsOf(withBoth)[0].state.rvcOperationalState.acceptedCommandList).to.deep.equal([0, 3, 128]);
+        });
+
+        it('initializes a fully equipped robot from its ioBroker states', async () => {
+            const mounted = await mount(Types.vacuumCleaner, {
+                POWER: bool(true),
+                RUN_MODE: enumeration(VACUUM_RUN_MODES, 1),
+                MODE: enumeration(VACUUM_MODES, 3),
+                STATE: enumeration(VACUUM_STATES, 1),
+                PAUSE: bool(false),
+                HOME: bool(false),
+            });
+            const [endpoint] = endpointsOf(mounted);
+            expect(endpoint.state.rvcRunMode.supportedModes.map((mode: any) => mode.mode)).to.deep.equal([0, 1, 2]);
+            expect(endpoint.state.rvcRunMode.currentMode).to.equal(1);
+            expect(endpoint.state.rvcCleanMode.supportedModes.map((mode: any) => mode.label)).to.deep.equal(
+                VACUUM_MODES,
+            );
+            expect(endpoint.state.rvcCleanMode.currentMode).to.equal(3);
+            expect(endpoint.state.rvcOperationalState.operationalState).to.equal(
+                RvcOperationalState.OperationalState.Running,
+            );
+        });
+
+        it('tags every clean mode as Vacuum so the cluster stays conformant', async () => {
+            const mounted = await mount(Types.vacuumCleaner, {
+                POWER: bool(false),
+                MODE: enumeration(VACUUM_MODES, 0),
+            });
+            const [endpoint] = endpointsOf(mounted);
+            const tagsOf = (label: string): number[] =>
+                endpoint.state.rvcCleanMode.supportedModes
+                    .find((mode: any) => mode.label === label)
+                    .modeTags.map((tag: any) => tag.value);
+            expect(tagsOf('NORMAL')).to.deep.equal([RvcCleanMode.ModeTag.Vacuum]);
+            expect(tagsOf('ECO')).to.deep.equal([RvcCleanMode.ModeTag.Vacuum, ModeBase.ModeTag.LowEnergy]);
+        });
+
+        it('does not add RvcCleanMode for a device that offers a single mode', async () => {
+            const mounted = await mount(Types.vacuumCleaner, {
+                POWER: bool(false),
+                MODE: enumeration(['AUTO'], 0),
+            });
+            const [endpoint] = endpointsOf(mounted);
+            // The cluster constrains supportedModes to 2 to 255 entries
+            expect(endpoint.behaviors.has('rvcCleanMode')).to.equal(false);
+        });
+
+        it('keeps duplicate ioBroker mode names apart, because Matter rejects a duplicate label', async () => {
+            const mounted = await mount(Types.vacuumCleaner, {
+                POWER: bool(false),
+                MODE: enumeration(['AUTO', 'AUTO', 'TURBO'], 0),
+            });
+            const [endpoint] = endpointsOf(mounted);
+            const labels = endpoint.state.rvcCleanMode.supportedModes.map((mode: any) => mode.label);
+            expect(labels).to.deep.equal(['AUTO', 'AUTO 1', 'TURBO']);
+            expect(new Set(labels).size).to.equal(labels.length);
+        });
+
+        it('crops a mode name to the 64 characters a Matter label holds', async () => {
+            const long = 'M'.repeat(80);
+            const mounted = await mount(Types.vacuumCleaner, {
+                POWER: bool(false),
+                MODE: enumeration([long, 'TURBO'], 0),
+            });
+            const [endpoint] = endpointsOf(mounted);
+            expect(endpoint.state.rvcCleanMode.supportedModes[0].label).to.equal('M'.repeat(64));
+        });
+
+        it('drops the Mapping run mode when the device does not offer it', async () => {
+            const mounted = await mount(Types.vacuumCleaner, {
+                POWER: bool(false),
+                RUN_MODE: enumeration(['IDLE', 'CLEANING'], 0),
+            });
+            const [endpoint] = endpointsOf(mounted);
+            expect(endpoint.state.rvcRunMode.supportedModes.map((mode: any) => mode.mode)).to.deep.equal([0, 1]);
+        });
+
+        it('follows an ioBroker run mode change into the cluster', async () => {
+            const mounted = await mount(Types.vacuumCleaner, {
+                POWER: bool(false),
+                RUN_MODE: enumeration(VACUUM_RUN_MODES, 0),
+                STATE: enumeration(VACUUM_STATES, 0),
+            });
+            const [endpoint] = endpointsOf(mounted);
+            await mounted.adapter.pushValue('RUN_MODE', 2);
+            expect(endpoint.state.rvcRunMode.currentMode).to.equal(2);
+            await mounted.adapter.pushValue('STATE', 1);
+            expect(endpoint.state.rvcOperationalState.operationalState).to.equal(
+                RvcOperationalState.OperationalState.Running,
+            );
+        });
+
+        it('writes a controller run mode change back to RUN_MODE and POWER', async () => {
+            const mounted = await mount(Types.vacuumCleaner, {
+                POWER: bool(false),
+                RUN_MODE: enumeration(VACUUM_RUN_MODES, 0),
+            });
+            const [endpoint] = endpointsOf(mounted);
+            const response = await invoke(endpoint, 'rvcRunMode', 'changeToMode', { newMode: 1 });
+            expect(response.status).to.equal(ModeBase.ModeChangeStatus.Success);
+            expect(mounted.device.getPropertyValue(PropertyType.RunMode)).to.equal('CLEANING');
+            expect(mounted.device.getPropertyValue(PropertyType.Power)).to.equal(true);
+        });
+
+        it('writes a controller clean mode change back to MODE', async () => {
+            const mounted = await mount(Types.vacuumCleaner, {
+                POWER: bool(false),
+                MODE: enumeration(VACUUM_MODES, 0),
+            });
+            const [endpoint] = endpointsOf(mounted);
+            await invoke(endpoint, 'rvcCleanMode', 'changeToMode', { newMode: 4 });
+            expect(mounted.device.getPropertyValue(PropertyType.Mode)).to.equal('EXPRESS');
+        });
+
+        it('turns pause, resume and go home into the ioBroker button states', async () => {
+            const mounted = await mount(Types.vacuumCleaner, {
+                POWER: bool(true),
+                PAUSE: bool(false),
+                HOME: bool(false),
+            });
+            const [endpoint] = endpointsOf(mounted);
+            expect(endpoint.state.rvcOperationalState.operationalState).to.equal(
+                RvcOperationalState.OperationalState.Running,
+            );
+
+            const paused = await invoke(endpoint, 'rvcOperationalState', 'pause');
+            expect(paused.commandResponseState.errorStateId).to.equal(RvcOperationalState.ErrorState.NoError);
+            expect(await mounted.adapter.getForeignStateAsync(mounted.adapter.idOf('PAUSE'))).to.include({ val: true });
+            // Without a STATE state the cluster has to report the result itself, or resume is refused afterwards
+            expect(endpoint.state.rvcOperationalState.operationalState).to.equal(
+                RvcOperationalState.OperationalState.Paused,
+            );
+
+            const resumed = await invoke(endpoint, 'rvcOperationalState', 'resume');
+            expect(resumed.commandResponseState.errorStateId).to.equal(RvcOperationalState.ErrorState.NoError);
+            expect(await mounted.adapter.getForeignStateAsync(mounted.adapter.idOf('PAUSE'))).to.include({
+                val: false,
+            });
+
+            await invoke(endpoint, 'rvcOperationalState', 'goHome');
+            expect(await mounted.adapter.getForeignStateAsync(mounted.adapter.idOf('HOME'))).to.include({ val: true });
+            expect(endpoint.state.rvcOperationalState.operationalState).to.equal(
+                RvcOperationalState.OperationalState.Docked,
+            );
+        });
+
+        it('leaves the operational state to STATE when the device reports one', async () => {
+            const mounted = await mount(Types.vacuumCleaner, {
+                POWER: bool(true),
+                RUN_MODE: enumeration(VACUUM_RUN_MODES, 1),
+                STATE: enumeration(VACUUM_STATES, 1),
+                PAUSE: bool(false),
+                HOME: bool(false),
+            });
+            const [endpoint] = endpointsOf(mounted);
+            expect(endpoint.state.rvcOperationalState.operationalState).to.equal(
+                RvcOperationalState.OperationalState.Running,
+            );
+
+            // A device that reports its own state must not have it guessed for it from a command or a run mode
+            await invoke(endpoint, 'rvcOperationalState', 'pause');
+            expect(endpoint.state.rvcOperationalState.operationalState).to.equal(
+                RvcOperationalState.OperationalState.Running,
+            );
+            await invoke(endpoint, 'rvcRunMode', 'changeToMode', { newMode: 0 });
+            expect(endpoint.state.rvcOperationalState.operationalState).to.equal(
+                RvcOperationalState.OperationalState.Running,
+            );
+
+            await mounted.adapter.pushValue('STATE', 2);
+            expect(endpoint.state.rvcOperationalState.operationalState).to.equal(
+                RvcOperationalState.OperationalState.Paused,
+            );
+            await mounted.adapter.pushValue('STATE', 0);
+            expect(endpoint.state.rvcOperationalState.operationalState).to.equal(
+                RvcOperationalState.OperationalState.Docked,
+            );
+        });
+
+        it('reports an idle ioBroker run mode as the idle Matter mode', async () => {
+            const mounted = await mount(Types.vacuumCleaner, {
+                POWER: bool(false),
+                RUN_MODE: enumeration(VACUUM_RUN_MODES, 0),
+            });
+            const [endpoint] = endpointsOf(mounted);
+            expect(endpoint.state.rvcRunMode.currentMode).to.equal(0);
+            expect(endpoint.state.rvcOperationalState.operationalState).to.equal(
+                RvcOperationalState.OperationalState.Docked,
+            );
+        });
+
+        it('falls back to the first clean mode when MODE holds a value the device does not list', async () => {
+            const mounted = await mount(Types.vacuumCleaner, {
+                POWER: bool(false),
+                MODE: { ...enumeration(VACUUM_MODES, 0), val: 99 },
+            });
+            const [endpoint] = endpointsOf(mounted);
+            expect(endpoint.state.rvcCleanMode.currentMode).to.equal(0);
+        });
+
+        it('carries every controller run mode into the ioBroker states', async () => {
+            const mounted = await mount(Types.vacuumCleaner, {
+                POWER: bool(false),
+                RUN_MODE: enumeration(VACUUM_RUN_MODES, 0),
+            });
+            const [endpoint] = endpointsOf(mounted);
+
+            await invoke(endpoint, 'rvcRunMode', 'changeToMode', { newMode: 2 });
+            expect(mounted.device.getPropertyValue(PropertyType.RunMode)).to.equal('MAPPING');
+            expect(mounted.device.getPropertyValue(PropertyType.Power)).to.equal(true);
+
+            await invoke(endpoint, 'rvcRunMode', 'changeToMode', { newMode: 0 });
+            expect(mounted.device.getPropertyValue(PropertyType.RunMode)).to.equal('IDLE');
+            expect(mounted.device.getPropertyValue(PropertyType.Power)).to.equal(false);
+        });
+
+        it('follows an ioBroker clean mode change into the cluster', async () => {
+            const mounted = await mount(Types.vacuumCleaner, {
+                POWER: bool(false),
+                MODE: enumeration(VACUUM_MODES, 0),
+            });
+            const [endpoint] = endpointsOf(mounted);
+            await mounted.adapter.pushValue('MODE', 4);
+            expect(endpoint.state.rvcCleanMode.currentMode).to.equal(4);
+        });
+
+        it('does not write an unsupported mode number back to ioBroker', async () => {
+            const mounted = await mount(Types.vacuumCleaner, {
+                POWER: bool(false),
+                RUN_MODE: enumeration(VACUUM_RUN_MODES, 0),
+                MODE: enumeration(VACUUM_MODES, 0),
+            });
+            const [endpoint] = endpointsOf(mounted);
+
+            const runMode = await invoke(endpoint, 'rvcRunMode', 'changeToMode', { newMode: 42 });
+            expect(runMode.status).to.equal(ModeBase.ModeChangeStatus.UnsupportedMode);
+            expect(mounted.device.getPropertyValue(PropertyType.RunMode)).to.equal('IDLE');
+
+            const cleanMode = await invoke(endpoint, 'rvcCleanMode', 'changeToMode', { newMode: 42 });
+            expect(cleanMode.status).to.equal(ModeBase.ModeChangeStatus.UnsupportedMode);
+            expect(mounted.device.getPropertyValue(PropertyType.Mode)).to.equal('AUTO');
+        });
+
+        it('refuses go home while the robot is already docked', async () => {
+            const mounted = await mount(Types.vacuumCleaner, { POWER: bool(false), HOME: bool(false) });
+            const [endpoint] = endpointsOf(mounted);
+            const response = await invoke(endpoint, 'rvcOperationalState', 'goHome');
+            expect(response.commandResponseState.errorStateId).to.equal(
+                RvcOperationalState.ErrorState.CommandInvalidInState,
+            );
+            expect(await mounted.adapter.getForeignStateAsync(mounted.adapter.idOf('HOME'))).to.include({ val: false });
+        });
+
+        it('raises and clears the operational error from the ioBroker ERROR state', async () => {
+            const mounted = await mount(Types.vacuumCleaner, {
+                POWER: bool(true),
+                STATE: enumeration(VACUUM_STATES, 1),
+                // The detector types ERROR as a string, so an empty text is what "no error" looks like
+                ERROR: { type: 'string', val: '' },
+            });
+            const [endpoint] = endpointsOf(mounted);
+            await mounted.adapter.pushValue('ERROR', 'Stuck');
+            expect(endpoint.state.rvcOperationalState.operationalState).to.equal(
+                RvcOperationalState.OperationalState.Error,
+            );
+            await mounted.adapter.pushValue('ERROR', '');
+            expect(endpoint.state.rvcOperationalState.operationalError.errorStateId).to.equal(
+                RvcOperationalState.ErrorState.NoError,
+            );
+            expect(endpoint.state.rvcOperationalState.operationalState).to.equal(
+                RvcOperationalState.OperationalState.Running,
+            );
         });
     });
 

--- a/test/toMatterEndpoints.test.ts
+++ b/test/toMatterEndpoints.test.ts
@@ -680,25 +680,70 @@ describe('to-matter converters for type-detector v6 device types', function () {
             expect(endpoint.behaviors.has('rvcCleanMode')).to.equal(false);
         });
 
-        it('keeps duplicate ioBroker mode names apart, because Matter rejects a duplicate label', async () => {
+        it('offers a repeated ioBroker mode name once, because a write could only ever reach the first', async () => {
             const mounted = await mount(Types.vacuumCleaner, {
                 POWER: bool(false),
                 MODE: enumeration(['AUTO', 'AUTO', 'TURBO'], 0),
             });
             const [endpoint] = endpointsOf(mounted);
-            const labels = endpoint.state.rvcCleanMode.supportedModes.map((mode: any) => mode.label);
-            expect(labels).to.deep.equal(['AUTO', 'AUTO 2', 'TURBO']);
-            expect(new Set(labels).size).to.equal(labels.length);
+            expect(endpoint.state.rvcCleanMode.supportedModes.map((mode: any) => mode.label)).to.deep.equal([
+                'AUTO',
+                'TURBO',
+            ]);
         });
 
-        it('keeps suffixing until a mode name is actually unique', async () => {
+        it('keeps two mode names apart that only collide once cropped', async () => {
+            const shared = 'M'.repeat(64);
             const mounted = await mount(Types.vacuumCleaner, {
                 POWER: bool(false),
-                MODE: enumeration(['AUTO', 'AUTO 2', 'AUTO'], 0),
+                MODE: enumeration([`${shared}A`, `${shared}B`], 0),
             });
             const [endpoint] = endpointsOf(mounted);
             const labels = endpoint.state.rvcCleanMode.supportedModes.map((mode: any) => mode.label);
-            expect(labels).to.deep.equal(['AUTO', 'AUTO 2', 'AUTO 3']);
+            expect(new Set(labels).size, 'Matter rejects a duplicate label').to.equal(2);
+            expect(Math.max(...labels.map((label: string) => label.length))).to.be.at.most(64);
+        });
+
+        it('caps the advertised modes at the 255 the cluster holds', async () => {
+            const mounted = await mount(Types.vacuumCleaner, {
+                POWER: bool(false),
+                MODE: enumeration(
+                    Array.from({ length: 300 }, (_, index) => `MODE_${index}`),
+                    0,
+                ),
+            });
+            const [endpoint] = endpointsOf(mounted);
+            expect(endpoint.state.rvcCleanMode.supportedModes).to.have.lengthOf(255);
+        });
+
+        it('lets a power change decide the run mode even while RUN_MODE disagrees', async () => {
+            const mounted = await mount(Types.vacuumCleaner, {
+                POWER: bool(true),
+                RUN_MODE: enumeration(VACUUM_RUN_MODES, 1),
+            });
+            const [endpoint] = endpointsOf(mounted);
+            expect(endpoint.state.rvcRunMode.currentMode).to.equal(1);
+
+            // RUN_MODE still says CLEANING, but the robot was just switched off
+            await mounted.adapter.pushValue('POWER', false);
+            expect(endpoint.state.rvcRunMode.currentMode).to.equal(0);
+            expect(endpoint.state.rvcOperationalState.operationalState).to.equal(
+                RvcOperationalState.OperationalState.Docked,
+            );
+
+            // Switching it on again has to leave it doing something
+            await mounted.adapter.pushValue('POWER', true);
+            expect(endpoint.state.rvcRunMode.currentMode).to.equal(1);
+        });
+
+        it('switches on into cleaning when RUN_MODE still says idle', async () => {
+            const mounted = await mount(Types.vacuumCleaner, {
+                POWER: bool(false),
+                RUN_MODE: enumeration(VACUUM_RUN_MODES, 0),
+            });
+            const [endpoint] = endpointsOf(mounted);
+            await mounted.adapter.pushValue('POWER', true);
+            expect(endpoint.state.rvcRunMode.currentMode).to.equal(1);
         });
 
         it('starts in Error with the error attribute that explains it', async () => {


### PR DESCRIPTION
Addresses #655 and #278 — the RoboticVacuumCleaner mapping both ask for. Neither is fully closed by this PR: #655 also carries endpoint-dump observations for other device types, and #278 asks for vacuum support across the adapter, of which this covers the Matter device type in both directions.

**Stacked on #871** (`feat/type-detector-v6`), which is where the `HOME`, `RUN_MODE`, `PROGRESS` and `PHASE` states this work maps onto live. Retarget to `main` once that merges.

## Controller direction

`RoboticVacuumCleanerToIoBroker` maps a paired robot (device type `0x74`) to the ioBroker `vacuumCleaner` type:

| Matter | ioBroker | notes |
|---|---|---|
| `RvcRunMode.currentMode` | `RUN_MODE`, `POWER` | resolved through `modeTags`, never the mode number |
| `RvcCleanMode.currentMode` | `MODE` | carries the robot's own mode labels |
| `RvcOperationalState.operationalState` | `STATE` | Running / Paused / one of the docked states |
| `RvcOperationalState.currentPhase` | `PHASE` | resolved against `phaseList`, cleared to `''` when there is no phase |
| `RvcOperationalState.operationalError` | `ERROR` | the error name, e.g. `DustBinFull` |
| `ServiceArea.progress` | `PROGRESS` | share of areas done; only with the `ProgressReporting` feature |
| `Pause` / `Resume` / `GoHome` | `PAUSE`, `HOME` | only when the robot lists the command |

## Bridge and device direction

`VacuumCleanerToMatter` exposes an ioBroker vacuum cleaner as a `RoboticVacuumCleanerDevice`, modelled on the matter.js `device-robotic-vacuum-cleaner` example. Because Matter derives the accepted command list from the methods a behavior implements, the operational-state server is picked from what the ioBroker device can back — a device without `PAUSE` advertises no Pause command rather than one that always fails.

`PHASE` and `PROGRESS` are deliberately **not** exposed in this direction. `phaseList` is an indexed vendor enumeration and `ServiceArea` is per cleaning area; an ioBroker vacuum cleaner knows neither, and populating them would mean inventing structure.

## Decisions worth a second opinion

- **`POWER` is derived from the run mode, in both directions.** The RVC device type has no OnOff cluster at all, while `POWER` is a *required* state of the ioBroker `vacuumCleaner` pattern. The bridge direction therefore has to map it onto `RvcRunMode` regardless, and the controller direction inverting the same mapping is the only symmetric answer. Idle is off.
- **`MODE` carries the robot's own labels** rather than the fixed `AUTO`/`ECO`/`EXPRESS`/`NORMAL`/`QUIET` enum. `RvcCleanMode`'s tags (`Vacuum`, `Mop`, `DeepClean`) name a floor treatment with no ioBroker counterpart, so squeezing them into an intensity enum would lose what the mode actually is.
- **`PAUSE` needs both `Pause` and `Resume`.** A robot advertising only one gets no `PAUSE` state rather than a one-way one.

## Two defects found on the way

- **`GenericDevice`'s `updateState` shadowed the `update<Property>` namespace.** `updatePropertyValue()` resolves `update` + the capitalised property name, so `PropertyType.State` resolved to `GenericDevice`'s own `protected updateState` *instance field* — meaning `'updateState' in this` was true on every device, and any device mapping `PropertyType.State` would have called the state-change forwarder with a raw scalar and thrown on `this.#properties[undefined]`. `Media` and `WeatherForecast` also declare `PropertyType.State`; neither is reachable from a converter today, so it was latent. Renamed to `#handleIoBrokerStateChange`.
- **One attribute path carried only one property mapping.** `#matterMappings` in `GenericDeviceToIoBroker` was a `Map` keyed by attribute path, so registering a second property against one path silently replaced the first, which then never updated again. This was not RVC-specific: **ten registrations across nine converters collided**, every `X`/`X_ACTUAL` pair among them — lights, plug, dimmer, lock and speaker — and each worked around the loss by updating the other property from its own `convertValue`. The path now carries every mapping registered for it, and the six workarounds are removed.
- **`ERROR` was declared `ValueType.Boolean`** while all 48 type-detector patterns give it `defaultType: 'string'` and no type constraint. Now declared as the string it is.
- **`#determineControlType` had an always-true condition** (`|| ValueType.NumberMinMax` instead of a comparison), so the `Enum → select` and text branches below it were unreachable and every enum or text state of a device rendered as a number field in the Device Manager.

- **A state fed by two Matter attributes could not be expressed.** `enableDeviceTypeStateForAttribute` returns early when a property is already enabled, so a second registration for the same property was silently dropped — the air purifier's carbon filter reached the shared `FILTER_CHANGE` only through a hand-written handler beside the registration, which reads as redundant and was duly deleted once during this PR. `enableDeviceTypeStateForAttributes` now takes the sources: each brings its own conversion, because the attribute that changed has to be combined with the ones that did not, and the first *supported* source owns the state so a purifier carrying only a carbon filter still gets it.

## Review feedback addressed

Copilot raised four points, all correct and all fixed:

- The `ERROR` `ValueType` inconsistency — which led to the `#determineControlType` bug above.
- An endpoint starting in `Error` left `operationalError` at `NoError`, so a controller saw an error with no cause. The error attribute is now seeded alongside the state.
- Both duplicate-name suffixes could themselves collide (`['AUTO', 'AUTO 2', 'AUTO']`). Both now count up until the value is actually free.

A second review then caught a regression from the reshape itself: removing the air purifier's carbon-filter handler as "redundant" was wrong, because the reshape lets a path carry several properties but does nothing for one property on several paths. That is what the new multi-source API above replaces it with, and an integration test now pushes a carbon change so the initial-value assertions can no longer hide it.

## Testing

- 305 unit tests, 227 integration tests, lint, lint-frontend, prettier and build all pass.
- The integration fixture gains two robots: a fully equipped one whose mode numbers are deliberately *not* the ioBroker ones (Cleaning is 3), which is what proves the tag-based resolution, and a minimal one with no clean mode, no optional commands and an empty progress list.
- New integration tests drive attribute *changes* through the production dispatch, not just the initial read — that gap is what hid the `RUN_MODE` bug.
- Mutation-tested per added branch. Killed: tag-based run-mode resolution, phase lookup, the command gating, the operational-state server selection, the `Vacuum` tag, the `RUN_MODE`-drives-`POWER` fix, the phase clearing, and two of the three `!hasState()` guards. The third turned out to be redundant and was removed rather than left as an untestable branch.
- One survivor, stated plainly: the empty-`progress` guard in `#progressOf` changes nothing observable, because `0/0` is `NaN` and the percent state object rejects it either way. It only avoids a spurious error log.

## Left for you to decide

`GenericDevice` still declares `ERROR` as `ValueType.Boolean` while the property is now `boolean | string` (the type detector defaults that state to a string). It is inert today — `DeviceStateObject` only branches on `Enum` and `NumberPercent` — but it is the one place the widening was not carried through, and changing a shared declaration affects every device type's `ERROR`.

## matter.js bug hit on the way

`ServiceAreaServer.initialize()` calls `#assertSupportedMaps(this.state.supportedMaps)` unconditionally, while the `currentArea` and `progress` asserts right above it are guarded with `!== undefined`. Without the `Maps` feature `supportedMaps` does not exist, so `ServiceAreaServer.with('ProgressReporting')` throws `Cannot read properties of undefined (reading 'length')`. Both fixture robots select `Maps` purely to work around this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

