### PR TITLE
Store the peer data of paired nodes in the objects database

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ Tests are located in the `test/` directory and use ts-node for direct TypeScript
 * (@Apollon77) Network visualization data is no longer assembled, and neither it nor Thread diagnostics data is serialized and sent, while no admin UI is listening
 * (@Apollon77) Updated matter.js to 0.18 and migrated the controller to its ClientNode API
 * (@Apollon77) A bridged pump no longer advertises the Matter Lighting feature on its level and on/off clusters, so its speed setpoint can reach zero as intended
+* (@Apollon77) Controller node data of paired nodes is stored in the objects database again, so an ioBroker backup carries the pairing data. The files below the instance data directory are kept as they are, so that downgrading to an earlier adapter version still finds the paired nodes. **Be careful when downgrading**: addresses learned after the update stay in the objects database only, so a downgraded instance may need a moment to rediscover its nodes.
 * (@Apollon77) Fix vendor specific attributes of paired nodes not being updated anymore
 * (@Apollon77) Fix the ioBroker structure of a paired node not being rebuilt when a bridge gains or loses a device
 * (@Apollon77) Fix leftover objects and observers when a node is removed, and no longer create a second node tree while removing one

--- a/src/main.ts
+++ b/src/main.ts
@@ -221,7 +221,11 @@ export class MatterAdapter extends Adapter {
         // state, which matter.js loads but its expiration cull never removes
         if (this.#instanceDataDir !== undefined) {
             try {
-                await fs.rm(this.#instanceDataDir, { recursive: true, force: true });
+                for (const entry of await fs.readdir(this.#instanceDataDir)) {
+                    if (StorageLayout.isNodeDataEntry(entry)) {
+                        await fs.rm(path.join(this.#instanceDataDir, entry), { recursive: true, force: true });
+                    }
+                }
             } catch (error) {
                 this.log.error(`Can not remove the node data in ${this.#instanceDataDir}: ${error.message}`);
             }

--- a/src/main.ts
+++ b/src/main.ts
@@ -217,6 +217,16 @@ export class MatterAdapter extends Adapter {
         await this.delObjectAsync('storage', { recursive: true });
         // clear all nodes in the controller
         await this.delObjectAsync('controller', { recursive: true });
+        // A peer keeps its cluster data here, and one left behind reads as a node without commissioning
+        // state, which matter.js loads but its expiration cull never removes
+        if (this.#instanceDataDir !== undefined) {
+            try {
+                await fs.rm(this.#instanceDataDir, { recursive: true, force: true });
+            } catch (error) {
+                this.log.error(`Can not remove the node data in ${this.#instanceDataDir}: ${error.message}`);
+            }
+        }
+
         // restart adapter
         this.restart();
     }
@@ -555,16 +565,7 @@ export class MatterAdapter extends Adapter {
                     adapter,
                     namespace,
                     namespace === 'controller' ? instanceDataDir : undefined,
-                    namespace === 'controller'
-                        ? (contexts: string[]): boolean =>
-                              // Legacy node data
-                              contexts[0]?.startsWith('node-') ||
-                              // Or new node data for endpoints (not internal clusters)
-                              (contexts[0] === 'nodes' &&
-                                  contexts[2] === 'endpoints' &&
-                                  contexts[1]?.startsWith('peer') &&
-                                  !Number.isNaN(contexts[4]))
-                        : undefined,
+                    namespace === 'controller' ? StorageLayout.isClusterData : undefined,
                 );
                 await store.initialize();
                 return store;

--- a/src/main.ts
+++ b/src/main.ts
@@ -227,7 +227,13 @@ export class MatterAdapter extends Adapter {
                     }
                 }
             } catch (error) {
-                this.log.error(`Can not remove the node data in ${this.#instanceDataDir}: ${error.message}`);
+                // Restarting now would load the files that are still there and copy them back into the
+                // objects database, so the nodes this reset reported as erased would simply return.
+                this.log.error(
+                    `Can not remove the node data in ${this.#instanceDataDir}: ${error.message}. The reset is ` +
+                        `incomplete, so the adapter is not restarted. Remove the directory by hand and restart.`,
+                );
+                return;
             }
         }
 

--- a/src/matter/ControllerNode.ts
+++ b/src/matter/ControllerNode.ts
@@ -127,6 +127,11 @@ export type {
  */
 const STRUCTURE_REBUILD_DELAY_MS = 5_000;
 
+/** What makes two discovery announcements the same device. */
+function discoveredDeviceIdentifier(device: CommissionableDevice): string {
+    return device.deviceIdentifier ?? JSON.stringify(device.addresses ?? []);
+}
+
 interface WatchedPeer {
     peer: ClientNode;
     observers: ObserverGroup;
@@ -1163,7 +1168,7 @@ class Controller implements GeneralNode {
                 return;
             }
             const device = RemoteDescriptor.fromLongForm(commissioning) as CommissionableDevice;
-            const identifier = device.deviceIdentifier ?? JSON.stringify(device.addresses ?? []);
+            const identifier = discoveredDeviceIdentifier(device);
             if (seen.has(identifier)) {
                 return;
             }
@@ -1201,10 +1206,21 @@ class Controller implements GeneralNode {
 
         discovery
             .then(async nodes => {
+                // Discovery collects a node per announcement, so a device that advertises repeatedly is
+                // in there as often as it did.
+                const reported = new Set<string>();
                 const result = nodes
                     .map(node => node.maybeStateOf(CommissioningClient))
                     .filter(commissioning => commissioning !== undefined)
-                    .map(commissioning => RemoteDescriptor.fromLongForm(commissioning) as CommissionableDevice);
+                    .map(commissioning => RemoteDescriptor.fromLongForm(commissioning) as CommissionableDevice)
+                    .filter(device => {
+                        const identifier = discoveredDeviceIdentifier(device);
+                        if (reported.has(identifier)) {
+                            return false;
+                        }
+                        reported.add(identifier);
+                        return true;
+                    });
                 await finish();
                 this.#adapter.log.info(`Discovering stopped. Found ${result.length} devices.`);
                 answer({ result });

--- a/src/matter/IoBrokerObjectStorage.ts
+++ b/src/matter/IoBrokerObjectStorage.ts
@@ -31,8 +31,13 @@ export class IoBrokerObjectStorage extends StorageDriver {
         this.#storeLocalChecker = storeLocalChecker;
     }
 
+    /** Nothing of ours is stored without a context, so the checker is never asked about the root. */
     #isLocallyStored(contexts: string[]): boolean {
-        return !!(this.#nodeDataStorageDirectory !== undefined && this.#storeLocalChecker?.(contexts));
+        return !!(
+            contexts.length &&
+            this.#nodeDataStorageDirectory !== undefined &&
+            this.#storeLocalChecker?.(contexts)
+        );
     }
 
     async initialize(): Promise<void> {
@@ -60,6 +65,78 @@ export class IoBrokerObjectStorage extends StorageDriver {
         }
 
         this.initialized = true;
+
+        try {
+            await this.#adoptStrandedNodeData();
+        } catch (error) {
+            // The data stays readable where it is, so a failed move must not keep the adapter from starting
+            this.#adapter.log.error(`[STORAGE] Cannot move node data into the objects database: ${error.message}`);
+        }
+    }
+
+    /**
+     * Copy node data the local checker no longer claims into the objects database.
+     *
+     * Until 1.3.1 the checker matched every context below a peer, so entries that belong in objects were
+     * written to disk instead and would read back as missing once the checker was corrected. The file is
+     * kept: a downgrade to a version that reads only files still finds its peers, at the price of the copy
+     * going stale, and an entry already in the objects database is left alone rather than written back.
+     */
+    async #adoptStrandedNodeData(): Promise<void> {
+        const local = this.#localStorageManager;
+        if (local === undefined) {
+            return;
+        }
+
+        // Only peer data is split between the two backends; anything else in the shared directory is not ours
+        const pending = new Array<string[]>();
+        if (this.#localContexts([]).includes('nodes')) {
+            pending.push(['nodes']);
+        }
+        let adopted = 0;
+        const stranded = new Array<string>();
+        while (pending.length) {
+            const contexts = pending.shift()!;
+            if (this.#isLocallyStored(contexts)) {
+                continue;
+            }
+            pending.push(...this.#localContexts(contexts).map(context => [...contexts, context]));
+
+            const values = await local.values(contexts);
+            for (const key of await local.keys(contexts)) {
+                const file = [...contexts, key].join('.');
+                if ((await this.#getFromObjects(contexts, key)) !== undefined) {
+                    continue;
+                }
+                if (!(key in values)) {
+                    // The file storage driver drops what it cannot parse, so this entry has no value to copy
+                    stranded.push(file);
+                    continue;
+                }
+
+                await this.#setKey(contexts, key, values[key]);
+                // #setKey reports a failed write in the log and returns rather than throwing
+                if ((await this.#getFromObjects(contexts, key)) === undefined) {
+                    stranded.push(file);
+                    continue;
+                }
+                adopted++;
+            }
+        }
+
+        if (adopted) {
+            this.#adapter.log.info(
+                `[STORAGE] Copied ${adopted} node data entries into the objects database. The files stay behind ` +
+                    `so that a downgrade to an earlier adapter version still finds its nodes.`,
+            );
+        }
+        if (stranded.length) {
+            this.#adapter.log.warn(
+                `[STORAGE] Could not copy ${stranded.length} node data entries into the objects database: ` +
+                    `${stranded.join(', ')}. They are still read from the instance data directory and copying ` +
+                    `them is retried on the next start.`,
+            );
+        }
     }
 
     async #clearNamespace(): Promise<void> {
@@ -82,7 +159,9 @@ export class IoBrokerObjectStorage extends StorageDriver {
             await this.#clearNamespace();
             return;
         }
-        if (this.#localStorageManager && this.#isLocallyStored(contexts)) {
+        if (this.#localStorageManager) {
+            // A wipe addresses a whole subtree, and matter.js erases a node at contexts above the one the
+            // checker answers for, so this cannot ask where a single key would be written.
             this.#adapter.log.info(`[STORAGE] Clearing all storage for ${contexts.join('$$')} in local storage`);
             await this.#localStorageManager.clearAll(contexts);
         }
@@ -122,6 +201,20 @@ export class IoBrokerObjectStorage extends StorageDriver {
         if (this.#localStorageManager && this.#isLocallyStored(contexts)) {
             return await this.#localStorageManager.get<T>(contexts, key);
         }
+        const value = await this.#getFromObjects<T>(contexts, key);
+        if (value !== undefined) {
+            return value;
+        }
+        if (!contexts.length) {
+            // Root level entries of the shared directory belong to other components, and reading one that is
+            // a directory throws rather than reporting nothing
+            return undefined;
+        }
+        // Entries #adoptStrandedNodeData could not move stay readable from where they were written
+        return this.#localStorageManager?.get<T>(contexts, key);
+    }
+
+    async #getFromObjects<T extends SupportedStorageTypes>(contexts: string[], key: string): Promise<T | undefined> {
         const oid = this.buildKey(contexts, key);
         try {
             const valueState = await this.#adapter.getStateAsync(oid);
@@ -154,50 +247,52 @@ export class IoBrokerObjectStorage extends StorageDriver {
     }
 
     contexts(contexts: string[]): string[] {
-        const result = new Array<string>();
-        result.push(...this.#localContexts(contexts));
+        // A peer keeps its cluster data in files and the rest in objects, so both backends report it and
+        // every consumer of this list would build its store twice.
+        const result = new Set<string>(this.#localContexts(contexts));
 
         const contextKeyStart = this.buildKey(contexts, '');
         const len = contextKeyStart.length;
 
-        const foundContexts = new Set<string>();
-        Array.from(this.#existingObjectIds.keys())
-            .filter(key => key.startsWith(contextKeyStart) && key.indexOf('$$', len) !== -1)
-            .forEach(key => {
-                const context = key.substring(len, key.indexOf('$$', len));
-                if (!foundContexts.has(context)) {
-                    foundContexts.add(context);
-                }
-            });
-        result.push(...Array.from(foundContexts.keys()));
-        return result;
+        for (const oid of this.#existingObjectIds) {
+            const separator = oid.indexOf('$$', len);
+            if (oid.startsWith(contextKeyStart) && separator !== -1) {
+                result.add(oid.substring(len, separator));
+            }
+        }
+        return [...result];
     }
 
     async keys(contexts: string[]): Promise<string[]> {
-        const results = new Array<string>();
+        const results = new Set<string>();
         // Nothing of ours is ever stored locally without a context, so root-level entries of the shared
         // directory belong to other components.
         if (this.#localStorageManager && contexts.length) {
-            results.push(...(await this.#localStorageManager.keys(contexts)));
+            for (const key of await this.#localStorageManager.keys(contexts)) {
+                results.add(key);
+            }
         }
 
         const contextKeyStart = this.buildKey(contexts, '');
         const len = contextKeyStart.length;
 
-        results.push(
-            ...Array.from(this.#existingObjectIds.keys())
-                .filter(key => key.startsWith(contextKeyStart) && key.indexOf('$$', len) === -1)
-                .map(key => key.substring(len)),
-        );
-        return results;
+        for (const oid of this.#existingObjectIds) {
+            if (oid.startsWith(contextKeyStart) && oid.indexOf('$$', len) === -1) {
+                results.add(oid.substring(len));
+            }
+        }
+        return [...results];
     }
 
     async values(contexts: string[]): Promise<Record<string, SupportedStorageTypes>> {
         const values =
             this.#localStorageManager && contexts.length ? await this.#localStorageManager.values(contexts) : {};
 
-        const keys = await this.keys(contexts);
-        for (const key of keys) {
+        const readFromFiles = this.#isLocallyStored(contexts);
+        for (const key of await this.keys(contexts)) {
+            if (readFromFiles && key in values) {
+                continue;
+            }
             values[key] = await this.get(contexts, key);
         }
         return values;
@@ -224,9 +319,11 @@ export class IoBrokerObjectStorage extends StorageDriver {
                     },
                     native: {},
                 });
-                this.#existingObjectIds.add(oid);
             }
             await this.#adapter.setState(oid, toJson(value), true);
+            // Only a key that carries a value counts as existing: `keys()` and `contexts()` are built from
+            // this set, and an object without a state reports a key that reads back as undefined.
+            this.#existingObjectIds.add(oid);
         } catch (error) {
             this.#adapter.log.error(`[STORAGE] Cannot save state ${oid}: ${error.message}`);
         }
@@ -269,5 +366,12 @@ export class IoBrokerObjectStorage extends StorageDriver {
             this.#adapter.log.error(`[STORAGE] Cannot delete state ${oid}: ${error.message}`);
         }
         this.#existingObjectIds.delete(oid);
+
+        if (this.#localStorageManager && contexts.length) {
+            // An entry #adoptStrandedNodeData could not move would be served again by get()
+            await this.#localStorageManager
+                .delete(contexts, key)
+                .catch(error => this.#adapter.log.warn(`[STORAGE] Cannot delete file for ${oid}: ${error.message}`));
+        }
     }
 }

--- a/src/matter/IoBrokerObjectStorage.ts
+++ b/src/matter/IoBrokerObjectStorage.ts
@@ -105,18 +105,24 @@ export class IoBrokerObjectStorage extends StorageDriver {
             const values = await local.values(contexts);
             for (const key of await local.keys(contexts)) {
                 const file = [...contexts, key].join('.');
-                if ((await this.#getFromObjects(contexts, key)) !== undefined) {
-                    continue;
-                }
-                if (!(key in values)) {
-                    // The file storage driver drops what it cannot parse, so this entry has no value to copy
-                    stranded.push(file);
-                    continue;
-                }
+                try {
+                    if (await this.#objectsHoldValue(contexts, key)) {
+                        continue;
+                    }
+                    if (!(key in values)) {
+                        // The file storage driver drops what it cannot parse, so there is no value to copy
+                        stranded.push(file);
+                        continue;
+                    }
 
-                await this.#setKey(contexts, key, values[key]);
-                // #setKey reports a failed write in the log and returns rather than throwing
-                if ((await this.#getFromObjects(contexts, key)) === undefined) {
+                    await this.#setKey(contexts, key, values[key]);
+                    // #setKey reports a failed write in the log and returns rather than throwing
+                    if (!(await this.#objectsHoldValue(contexts, key))) {
+                        stranded.push(file);
+                        continue;
+                    }
+                } catch (error) {
+                    this.#adapter.log.warn(`[STORAGE] Cannot read ${file} from the objects database: ${error.message}`);
                     stranded.push(file);
                     continue;
                 }
@@ -212,6 +218,17 @@ export class IoBrokerObjectStorage extends StorageDriver {
         }
         // Entries #adoptStrandedNodeData could not move stay readable from where they were written
         return this.#localStorageManager?.get<T>(contexts, key);
+    }
+
+    /**
+     * Whether the objects database holds a value for this entry.
+     *
+     * Throws when the database cannot be read, because treating that as "absent" would copy the file over a
+     * value that is only unreadable right now.
+     */
+    async #objectsHoldValue(contexts: string[], key: string): Promise<boolean> {
+        const valueState = await this.#adapter.getStateAsync(this.buildKey(contexts, key));
+        return typeof valueState?.val === 'string';
     }
 
     async #getFromObjects<T extends SupportedStorageTypes>(contexts: string[], key: string): Promise<T | undefined> {

--- a/src/matter/IoBrokerObjectStorage.ts
+++ b/src/matter/IoBrokerObjectStorage.ts
@@ -15,6 +15,12 @@ export class IoBrokerObjectStorage extends StorageDriver {
     readonly #adapter: ioBroker.Adapter;
     #namespace: string;
     #localStorageManager?: FileStorageDriver;
+    /**
+     * Contexts wiped from the file backend, which keeps them in its index until it is recreated. An emptied
+     * peer that is still reported reads as a node without commissioning state - one matter.js loads and its
+     * expiration cull never removes.
+     */
+    readonly #clearedLocalContexts = new Set<string>();
     #storeLocalChecker?: (contexts: string[]) => boolean;
 
     constructor(
@@ -170,6 +176,7 @@ export class IoBrokerObjectStorage extends StorageDriver {
             // checker answers for, so this cannot ask where a single key would be written.
             this.#adapter.log.info(`[STORAGE] Clearing all storage for ${contexts.join('$$')} in local storage`);
             await this.#localStorageManager.clearAll(contexts);
+            this.#clearedLocalContexts.add(contexts.join('.'));
         }
 
         const contextKey = `${this.#adapter.namespace}.${this.buildKey(contexts, '')}`;
@@ -265,7 +272,12 @@ export class IoBrokerObjectStorage extends StorageDriver {
      * named "". Passing that on makes `clearAll` throw on the empty segment.
      */
     #localContexts(contexts: string[]): string[] {
-        return this.#localStorageManager?.contexts(contexts).filter(name => name.length > 0) ?? [];
+        return (
+            this.#localStorageManager
+                ?.contexts(contexts)
+                .filter(name => name.length > 0)
+                .filter(name => !this.#clearedLocalContexts.has([...contexts, name].join('.'))) ?? []
+        );
     }
 
     contexts(contexts: string[]): string[] {
@@ -357,6 +369,7 @@ export class IoBrokerObjectStorage extends StorageDriver {
         value?: SupportedStorageTypes,
     ): Promise<void> {
         if (this.#localStorageManager && this.#isLocallyStored(contexts)) {
+            this.#clearedLocalContexts.clear();
             return this.#localStorageManager.set(contexts, keyOrValue as string, value);
         }
 

--- a/src/matter/IoBrokerObjectStorage.ts
+++ b/src/matter/IoBrokerObjectStorage.ts
@@ -216,6 +216,11 @@ export class IoBrokerObjectStorage extends StorageDriver {
             // a directory throws rather than reporting nothing
             return undefined;
         }
+        if (this.#existingObjectIds.has(this.buildKey(contexts, key))) {
+            // The objects database owns this entry, so a read that failed must report nothing rather than
+            // the copy #adoptStrandedNodeData left behind, which is older by definition.
+            return undefined;
+        }
         // Entries #adoptStrandedNodeData could not move stay readable from where they were written
         return this.#localStorageManager?.get<T>(contexts, key);
     }
@@ -377,18 +382,17 @@ export class IoBrokerObjectStorage extends StorageDriver {
 
         const oid = this.buildKey(contexts, key);
 
+        // The copy #adoptStrandedNodeData left behind goes first and its failure is not swallowed: while it
+        // is there, the value the objects database still holds is what keeps `get()` from serving it again.
+        if (this.#localStorageManager && contexts.length) {
+            await this.#localStorageManager.delete(contexts, key);
+        }
+
         try {
             await this.#adapter.delObjectAsync(oid);
         } catch (error) {
             this.#adapter.log.error(`[STORAGE] Cannot delete state ${oid}: ${error.message}`);
         }
         this.#existingObjectIds.delete(oid);
-
-        if (this.#localStorageManager && contexts.length) {
-            // An entry #adoptStrandedNodeData could not move would be served again by get()
-            await this.#localStorageManager
-                .delete(contexts, key)
-                .catch(error => this.#adapter.log.warn(`[STORAGE] Cannot delete file for ${oid}: ${error.message}`));
-        }
     }
 }

--- a/src/matter/storageLayout.ts
+++ b/src/matter/storageLayout.ts
@@ -43,6 +43,16 @@ export namespace StorageLayout {
         );
     }
 
+    /**
+     * Whether a file in the instance data directory belongs to the controller node store.
+     *
+     * A relocation that found its target occupied leaves the source behind, so the directory can also hold
+     * the user's own OTA images, which a reset must not take with it.
+     */
+    export function isNodeDataEntry(name: string): boolean {
+        return name.startsWith('nodes.') || name.startsWith('node-');
+    }
+
     export interface Targets {
         /** Root for the files matter.js downloads and can fetch again. */
         cacheDir: string;

--- a/src/matter/storageLayout.ts
+++ b/src/matter/storageLayout.ts
@@ -23,6 +23,26 @@ export namespace StorageLayout {
         { name: 'custom-ota', to: targets.customOtaDir },
     ];
 
+    /**
+     * Whether a controller storage entry holds cluster data of a paired node.
+     *
+     * Those attributes change with every report, so they stay in the instance data directory instead of
+     * becoming ioBroker states. The rest of what a peer stores — its commissioning and network state —
+     * is small, changes rarely, and belongs in the objects database with everything else.
+     */
+    export function isClusterData(contexts: string[]): boolean {
+        // Peer data of matter.js 0.17 and earlier, kept where it was written
+        if (contexts[0]?.startsWith('node-')) {
+            return true;
+        }
+        return (
+            contexts[0] === 'nodes' &&
+            contexts[1]?.startsWith('peer') === true &&
+            contexts[2] === 'endpoints' &&
+            /^\d+$/.test(contexts[4] ?? '')
+        );
+    }
+
     export interface Targets {
         /** Root for the files matter.js downloads and can fetch again. */
         cacheDir: string;

--- a/test/ioBrokerObjectStorage.test.ts
+++ b/test/ioBrokerObjectStorage.test.ts
@@ -1,8 +1,9 @@
 import { deepStrictEqual, ok, strictEqual } from 'node:assert';
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { IoBrokerObjectStorage } from '../src/matter/IoBrokerObjectStorage';
+import { StorageLayout } from '../src/matter/storageLayout';
 
 const NAMESPACE = 'matter.0';
 
@@ -198,6 +199,168 @@ describe('IoBrokerObjectStorage', () => {
                 'storage.uuid-1.fabrics$$key',
                 'storage.uuid-1.nodes$$peer1$$key',
             ]);
+        });
+    });
+
+    describe('node data stranded in the instance data directory', () => {
+        // Until 1.3.1 the checker matched every context below a peer, so `commissioning` and `network`
+        // were written to disk although they belong in the objects database.
+        const strandingChecker = (contexts: string[]): boolean =>
+            contexts[0]?.startsWith('node-') ||
+            (contexts[0] === 'nodes' && contexts[2] === 'endpoints' && contexts[1]?.startsWith('peer'));
+
+        const COMMISSIONING = ['nodes', 'peer1', 'endpoints', '0', 'commissioning'];
+        const CLUSTER = ['nodes', 'peer1', 'endpoints', '0', '40'];
+
+        async function withStrandedData(
+            test: (storage: IoBrokerObjectStorage, mock: MockAdapter, dir: string) => Promise<void>,
+        ): Promise<void> {
+            const dir = mkdtempSync(join(tmpdir(), 'iobroker-matter-storage-'));
+            try {
+                const mock = makeAdapter();
+                const stranding = new IoBrokerObjectStorage(mock.adapter, 'controller', dir, strandingChecker);
+                await stranding.initialize();
+                await stranding.set(COMMISSIONING, 'peerAddress', '{"fabricIndex":1}');
+                await stranding.set(CLUSTER, '3', 'Test Product');
+                await stranding.set(['node-15398113178295236884', '0', '29'], '0', 'legacy');
+                await stranding.close();
+                deepStrictEqual([...mock.objects], ['storage.controller']);
+
+                const storage = new IoBrokerObjectStorage(mock.adapter, 'controller', dir, StorageLayout.isClusterData);
+                await storage.initialize();
+                await test(storage, mock, dir);
+                await storage.close();
+            } finally {
+                rmSync(dir, { recursive: true, force: true });
+            }
+        }
+
+        it('copies what belongs in the objects database, and keeps the file for a downgrade', async () => {
+            await withStrandedData(async (storage, { objects }, dir) => {
+                strictEqual(await storage.get(COMMISSIONING, 'peerAddress'), '{"fabricIndex":1}');
+                ok(objects.has('storage.controller.nodes$$peer1$$endpoints$$0$$commissioning$$peerAddress'));
+                ok(existsSync(join(dir, 'nodes.peer1.endpoints.0.commissioning.peerAddress')));
+            });
+        });
+
+        it('leaves cluster data and the legacy layout on disk', async () => {
+            await withStrandedData(async (storage, { objects }, dir) => {
+                strictEqual(await storage.get(CLUSTER, '3'), 'Test Product');
+                strictEqual(await storage.get(['node-15398113178295236884', '0', '29'], '0'), 'legacy');
+                ok(existsSync(join(dir, 'nodes.peer1.endpoints.0.40.3')));
+                deepStrictEqual(
+                    [...objects].filter(id => id.includes('$$40$$') || id.includes('node-')),
+                    [],
+                );
+            });
+        });
+
+        it('wipes the cluster files of a node that matter.js erases', async () => {
+            // A node is erased at three context depths, none of which names a cluster:
+            // ClientEndpointStore.erase(), ClientNodeStore.erase() and ClientNodeStores.erase().
+            for (const erased of [['nodes', 'peer1', 'endpoints', '0'], ['nodes', 'peer1', 'endpoints'], ['nodes']]) {
+                const dir = mkdtempSync(join(tmpdir(), 'iobroker-matter-storage-'));
+                try {
+                    const mock = makeAdapter();
+                    const storage = new IoBrokerObjectStorage(
+                        mock.adapter,
+                        'controller',
+                        dir,
+                        StorageLayout.isClusterData,
+                    );
+                    await storage.initialize();
+                    await storage.set(CLUSTER, '3', 'Test Product');
+                    await storage.set(COMMISSIONING, 'peerAddress', '{"fabricIndex":1}');
+                    ok(existsSync(join(dir, 'nodes.peer1.endpoints.0.40.3')));
+
+                    await storage.clearAll(erased);
+
+                    ok(!existsSync(join(dir, 'nodes.peer1.endpoints.0.40.3')), `left behind by ${erased.join('$$')}`);
+                    strictEqual(await storage.get(CLUSTER, '3'), undefined);
+                    await storage.close();
+                } finally {
+                    rmSync(dir, { recursive: true, force: true });
+                }
+            }
+        });
+
+        it('reports a peer once although both backends hold part of it', async () => {
+            await withStrandedData(async storage => {
+                deepStrictEqual(storage.contexts(['nodes']), ['peer1']);
+                deepStrictEqual(storage.contexts(['nodes', 'peer1', 'endpoints']), ['0']);
+            });
+        });
+
+        it('does not serve a deleted value from a file that could not be moved', async () => {
+            await withStrandedData(async (storage, mock, dir) => {
+                // The move of this entry failed, so both a file and, from now on, the objects entry exist
+                mock.states.delete(
+                    `${NAMESPACE}.storage.controller.nodes$$peer1$$endpoints$$0$$commissioning$$peerAddress`,
+                );
+                writeFileSync(
+                    join(dir, 'nodes.peer1.endpoints.0.commissioning.peerAddress'),
+                    '"{\\"fabricIndex\\":1}"',
+                );
+
+                await storage.delete(COMMISSIONING, 'peerAddress');
+
+                strictEqual(await storage.get(COMMISSIONING, 'peerAddress'), undefined);
+                deepStrictEqual(await storage.values(COMMISSIONING), {});
+            });
+        });
+
+        it('leaves an entry the objects database already holds alone', async () => {
+            const dir = mkdtempSync(join(tmpdir(), 'iobroker-matter-storage-'));
+            try {
+                const mock = makeAdapter();
+                const stranding = new IoBrokerObjectStorage(mock.adapter, 'controller', dir, strandingChecker);
+                await stranding.initialize();
+                await stranding.set(COMMISSIONING, 'peerAddress', '{"fabricIndex":1}');
+                await stranding.close();
+
+                // The copy already happened once, and the peer has reported a new address since
+                const current = new IoBrokerObjectStorage(mock.adapter, 'controller', dir, StorageLayout.isClusterData);
+                await current.initialize();
+                await current.set(COMMISSIONING, 'peerAddress', '{"fabricIndex":2}');
+                await current.close();
+
+                const storage = new IoBrokerObjectStorage(mock.adapter, 'controller', dir, StorageLayout.isClusterData);
+                await storage.initialize();
+
+                strictEqual(await storage.get(COMMISSIONING, 'peerAddress'), '{"fabricIndex":2}');
+                await storage.close();
+            } finally {
+                rmSync(dir, { recursive: true, force: true });
+            }
+        });
+
+        it('keeps the file when the objects database refuses the value', async () => {
+            const dir = mkdtempSync(join(tmpdir(), 'iobroker-matter-storage-'));
+            try {
+                const mock = makeAdapter();
+                const stranding = new IoBrokerObjectStorage(mock.adapter, 'controller', dir, strandingChecker);
+                await stranding.initialize();
+                await stranding.set(COMMISSIONING, 'peerAddress', '{"fabricIndex":1}');
+                await stranding.close();
+
+                // The storage driver logs a write failure and carries on, so a lost write must not take the
+                // last copy of the value with it.
+                mock.adapter.setState = (() => {
+                    throw new Error('objects database unavailable');
+                }) as unknown as ioBroker.Adapter['setState'];
+
+                const storage = new IoBrokerObjectStorage(mock.adapter, 'controller', dir, StorageLayout.isClusterData);
+                await storage.initialize();
+
+                ok(existsSync(join(dir, 'nodes.peer1.endpoints.0.commissioning.peerAddress')));
+                // The file is only worth keeping if it is still the value the storage hands out
+                strictEqual(await storage.get(COMMISSIONING, 'peerAddress'), '{"fabricIndex":1}');
+                deepStrictEqual(await storage.values(COMMISSIONING), { peerAddress: '{"fabricIndex":1}' });
+                deepStrictEqual(await storage.keys(COMMISSIONING), ['peerAddress']);
+                await storage.close();
+            } finally {
+                rmSync(dir, { recursive: true, force: true });
+            }
         });
     });
 });

--- a/test/ioBrokerObjectStorage.test.ts
+++ b/test/ioBrokerObjectStorage.test.ts
@@ -294,9 +294,8 @@ describe('IoBrokerObjectStorage', () => {
         it('does not serve a deleted value from a file that could not be moved', async () => {
             await withStrandedData(async (storage, mock, dir) => {
                 // The move of this entry failed, so both a file and, from now on, the objects entry exist
-                mock.states.delete(
-                    `${NAMESPACE}.storage.controller.nodes$$peer1$$endpoints$$0$$commissioning$$peerAddress`,
-                );
+                // The mock keeps the ids the driver passes, which carry no adapter namespace
+                mock.states.delete('storage.controller.nodes$$peer1$$endpoints$$0$$commissioning$$peerAddress');
                 writeFileSync(
                     join(dir, 'nodes.peer1.endpoints.0.commissioning.peerAddress'),
                     '"{\\"fabricIndex\\":1}"',

--- a/test/ioBrokerObjectStorage.test.ts
+++ b/test/ioBrokerObjectStorage.test.ts
@@ -308,6 +308,20 @@ describe('IoBrokerObjectStorage', () => {
             });
         });
 
+        it('reports nothing rather than the older file when the objects database cannot be read', async () => {
+            await withStrandedData(async (storage, mock, dir) => {
+                writeFileSync(
+                    join(dir, 'nodes.peer1.endpoints.0.commissioning.peerAddress'),
+                    '"{\\"fabricIndex\\":1}"',
+                );
+                mock.adapter.getStateAsync = (() => {
+                    throw new Error('objects database unavailable');
+                }) as unknown as ioBroker.Adapter['getStateAsync'];
+
+                strictEqual(await storage.get(COMMISSIONING, 'peerAddress'), undefined);
+            });
+        });
+
         it('leaves an entry the objects database already holds alone', async () => {
             const dir = mkdtempSync(join(tmpdir(), 'iobroker-matter-storage-'));
             try {

--- a/test/ioBrokerObjectStorage.test.ts
+++ b/test/ioBrokerObjectStorage.test.ts
@@ -284,6 +284,26 @@ describe('IoBrokerObjectStorage', () => {
             }
         });
 
+        it('stops reporting a peer whose files were wiped', async () => {
+            const dir = mkdtempSync(join(tmpdir(), 'iobroker-matter-storage-'));
+            try {
+                const mock = makeAdapter();
+                const storage = new IoBrokerObjectStorage(mock.adapter, 'controller', dir, StorageLayout.isClusterData);
+                await storage.initialize();
+                await storage.set(CLUSTER, '3', 'Test Product');
+                deepStrictEqual(storage.contexts(['nodes']), ['peer1']);
+
+                await storage.clearAll(['nodes', 'peer1', 'endpoints', '0']);
+
+                // The file driver keeps an emptied context in its index, and a peer reported without data
+                // reads as a node matter.js loads but never culls
+                deepStrictEqual(storage.contexts(['nodes', 'peer1', 'endpoints']), []);
+                await storage.close();
+            } finally {
+                rmSync(dir, { recursive: true, force: true });
+            }
+        });
+
         it('reports a peer once although both backends hold part of it', async () => {
             await withStrandedData(async storage => {
                 deepStrictEqual(storage.contexts(['nodes']), ['peer1']);


### PR DESCRIPTION
Stacked on #869 — review that one first; this PR's diff is only the storage change.

## Why

The checker deciding which controller data stays in the instance data directory tested `!Number.isNaN(contexts[4])`. `Number.isNaN` does not coerce, so that clause was true for every string and **all** data of a paired node went to files instead of only the cluster attributes that change with every report. The pairing data went with it, so an ioBroker backup of the objects database did not carry it. The bug dates back to the 0.17 update (#801).

## What changes

- `StorageLayout.isClusterData` matches the digits of a cluster id, with the legacy `node-*` layout still claimed.
- The misplaced entries are copied into the objects database on start. **The file is kept as it is**, so an adapter version that reads only files still finds its paired nodes; an entry the objects database already holds is skipped, so a value written since the copy is never overwritten by the older file.
- An entry that cannot be copied stays readable from the file it is in and is retried on the next start. An entry is deleted from disk only after the copy is read back, because a failed write is logged rather than thrown.
- Deleting an entry drops its file too, otherwise the read fallback serves a deleted value and the next start copies it back.
- A wipe no longer asks the checker where a single key would be written: matter.js erases a node at contexts above the one the checker answers for, which left the cluster files of a decommissioned node behind, and a leftover peer that the expiration cull can never remove.
- Both backends now hold part of a peer, so the context and key listings report it once rather than twice.
- A total reset removes the node data directory as well, for the same leftover-peer reason.

## Downgrade

Documented in the changelog: the kept file goes stale, because addresses learned after the update land in the objects database only, so a downgraded instance may need a moment to rediscover its nodes.

## Tests

Seven cases in `test/ioBrokerObjectStorage.test.ts` cover the copy, the kept file, the skip of an entry already in the database, a refused write, a deleted value, the wipe at each of the three contexts matter.js erases at, and the single listing per peer. Each production hunk was mutation-proven: reverting it fails a specific case.